### PR TITLE
Fix issue with use_hint

### DIFF
--- a/amstramdam/datasets/dataframe.py
+++ b/amstramdam/datasets/dataframe.py
@@ -233,16 +233,10 @@ class UnifiedDataFrame:
         if not renamed:
             return self.df.loc[self.mask].to_dict(*args, **kwargs)  # type: ignore
         renamed_df = self.df.loc[self.mask].rename(columns=self.reversed_converter)
-        if "hint" not in renamed_df.columns:
-            renamed_df = pd.concat(
-                [renamed_df, pd.Series("", index=renamed_df.index, name="hint")],
-                axis="columns",
-            )
+        if "hint" not in renamed_df.columns or not self.use_hint:
+            renamed_df["hint"] = ""
         if "group" not in renamed_df.columns:
-            renamed_df = pd.concat(
-                [renamed_df, pd.Series(0, index=renamed_df.index, name="group")],
-                axis="columns",
-            )
+            renamed_df["group"] = 0
         return renamed_df.to_dict(*args, **kwargs)  # type: ignore
 
     @property

--- a/amstramdam/game/game_full.py
+++ b/amstramdam/game/game_full.py
@@ -83,7 +83,7 @@ class Game:
         dist_param: Optional[int] = None,
         is_permanent: bool = False,
         precision_mode: bool = False,
-        difficulty: int = 1,
+        difficulty: int = 0,
         is_public: bool = False,
         creation_date: Optional[datetime] = None,
         allow_zoom: bool = False,


### PR DESCRIPTION
Before this fix, hints were always displayed, even when setting `use_hint: false` in `datasets.json`