### PR TITLE
Randomly generate private game names

### DIFF
--- a/amstramdam/game/game_full.py
+++ b/amstramdam/game/game_full.py
@@ -1,16 +1,17 @@
 from typing import Any, Iterable, Optional, Union
 import string
 from collections import defaultdict, Counter
+from datetime import datetime, timedelta
 
 import pandas as pd
 import numpy as np
 
 from .game import GameRun, load_cities, PlaceToGuess
 from ..datasets import dataloader
-from datetime import datetime, timedelta
 import random
 import amstramdam.game.status as status
 from amstramdam.datasets.game_map import GameMap
+from amstramdam import utils
 from .types import (
     Player,
     Pseudo,
@@ -150,14 +151,7 @@ class Game:
         # self.run_in_progress = False
 
     def get_new_id(self) -> str:
-        return "".join(
-            random.choices(
-                string.ascii_lowercase + string.ascii_uppercase + string.digits, k=16
-            )
-        )
-        # curr_id = self.__id_counter
-        # self.__id_counter += 1
-        # return str(curr_id)
+        return utils.random.generate_random_identifier(length=16)
 
     def generate_player_name(self) -> Player:
         return Player(f"{self.name}_{self.get_new_id()}")

--- a/amstramdam/game/manager.py
+++ b/amstramdam/game/manager.py
@@ -5,6 +5,8 @@ import random
 from typing import Any, Optional, Generator
 from unidecode import unidecode
 from amstramdam.game.types import GameName, AvailableGames
+from amstramdam import utils
+
 
 with open("data/game_names.txt", "r", encoding="utf8", errors="ignore") as f:
     VALID_GAME_NAMES = {GameName(unidecode(line.rstrip())) for line in f}
@@ -22,6 +24,8 @@ def create_game(
         if name in MANAGER:
             disambig[name] += 1
             name = GameName(f"{name}_{disambig[name]}")
+    elif not kwargs.get("is_public", True):
+        name = GameName(utils.random.generate_random_identifier(12))
     else:
         names = list(VALID_GAME_NAMES - MANAGER.keys())
         if names:

--- a/amstramdam/utils/__init__.py
+++ b/amstramdam/utils/__init__.py
@@ -1,0 +1,1 @@
+import amstramdam.utils.random as random

--- a/amstramdam/utils/random.py
+++ b/amstramdam/utils/random.py
@@ -1,0 +1,9 @@
+import random
+import string
+
+CHARS = string.digits + string.ascii_lowercase + string.ascii_uppercase
+
+
+def generate_random_identifier(length: int) -> str:
+    """Generate a random alphanumeric identifier of given length"""
+    return "".join(random.choices(CHARS, k=length))


### PR DESCRIPTION
Before, one could access private games by 'bruteforcing' the not so long list of valid names. Now, private games have randomly generated names (12 alphanumeric characters, i.e 3.2e21 combinations).