### PR TITLE
Move player management to PlayerList

### DIFF
--- a/amstramdam/events/__init__.py
+++ b/amstramdam/events/__init__.py
@@ -1,3 +1,3 @@
 from .connect import init_game, leave_game
 from .game import launch_game, process_guess
-from .user import process_chat_message, update_pseudo
+from .user import process_chat_message, update_nickname

--- a/amstramdam/events/connect.py
+++ b/amstramdam/events/connect.py
@@ -41,7 +41,7 @@ def init_game(data: ConnectionPayload) -> None:
         if player not in game.players:
             game.add_player(player, pseudo)
     else:
-        player, pseudo = game.add_player(pseudo=pseudo)
+        player, pseudo = game.add_player(nickname=pseudo)
         session["player"] = player
 
     print(f"Player <{player}> connected to game <{game_name}> with pseudo <{pseudo}>")
@@ -56,10 +56,9 @@ def init_game(data: ConnectionPayload) -> None:
             current=game.curr_run_id,
             runs=game.n_run,
             diff=game.difficulty,
-            # precision=game.precision_mode,
             game_name=game.map_display_name,
             leaderboard=leaderboard,
-            pseudos=game.pseudos,
+            pseudos=game.players.nicknames,
         ),
     )
     emit(

--- a/amstramdam/events/user.py
+++ b/amstramdam/events/user.py
@@ -45,22 +45,22 @@ def process_chat_message(message: str) -> None:
 
 
 @socketio.on("name-change")
-def update_pseudo(data: NameChangePayload) -> None:
+def update_nickname(data: NameChangePayload) -> None:
     game_name: GameName = session["game"]
     player: Optional[Player] = session.get("player")
     game = manager.get_game(game_name)
     if player is None or game is None:
         return
 
-    pseudo = data["name"]
-    if is_valid_pseudo(pseudo):
-        pseudo = process_pseudo(pseudo)
-        game.add_pseudo(player, pseudo)
+    nickname = data["name"]
+    if is_valid_pseudo(nickname):
+        nickname = process_pseudo(nickname)
+        game.players.add_nickname(player, nickname)
     else:
-        pseudo = game.request_pseudo(player)
+        nickname = game.players.request_nickname(player)
     emit(
         "new-name",
-        NewNameNotification(player=player, pseudo=pseudo),
+        NewNameNotification(player=player, pseudo=nickname),
         room=game_name,
         broadcast=True,
         json=True,

--- a/amstramdam/events/user.py
+++ b/amstramdam/events/user.py
@@ -12,21 +12,8 @@ from amstramdam.events.types import (
     GameChangeNotification,
 )
 from amstramdam.game.params_handler import merge_params
-from amstramdam.game.types import GameName, Pseudo, Player
-
-MAX_LEN = 20
-
-
-def is_valid_pseudo(name: str) -> bool:
-    # TODO: implement checks?
-    name = str(name)
-    return len(name) > 0
-
-
-def process_pseudo(name: str) -> Pseudo:
-    if len(name) > MAX_LEN + 3:
-        name = name[:MAX_LEN] + "..."
-    return Pseudo(name)
+from amstramdam.game.types import GameName, Player
+from amstramdam import utils
 
 
 @socketio.on("chat:send")
@@ -53,8 +40,8 @@ def update_nickname(data: NameChangePayload) -> None:
         return
 
     nickname = data["name"]
-    if is_valid_pseudo(nickname):
-        nickname = process_pseudo(nickname)
+    if utils.nickname.is_valid(nickname):
+        nickname = utils.nickname.clean(nickname)
         game.players.add_nickname(player, nickname)
     else:
         nickname = game.players.request_nickname(player)

--- a/amstramdam/game/game.py
+++ b/amstramdam/game/game.py
@@ -123,7 +123,7 @@ class GameRun:
         t = 0.2 * self.SCORE_MULTIPLIER
         # Last n kilometers for the non-linear bonus
         g = 0.2 * self.dist_param
-        return (t / g ** 2) * max(0, g - dist) ** 2
+        return (t / g**2) * max(0, g - dist) ** 2
 
     def dist_score(self, dist: float, non_linear: Optional[bool] = None) -> float:
         s = self.SCORE_MULTIPLIER * max(0, 1 - (dist / self.dist_param))

--- a/amstramdam/game/players.py
+++ b/amstramdam/game/players.py
@@ -1,0 +1,117 @@
+import random
+from typing import Generator
+
+from amstramdam.game.types import Player, Pseudo
+from amstramdam import utils
+
+
+NICKNAME_FILE = "data/player_names.txt"
+with open("data/player_names.txt", "r", encoding="utf8", errors="ignore") as f:
+    NICKNAMES: set[Pseudo] = {Pseudo(line.rstrip()) for line in f}
+_global_player_list: set[Player] = set()
+
+
+class PlayerList:
+    """Store the list of players and their nicknames
+
+    `PlayerList` contains methods to add/rename/remove players from the player list
+    """
+
+    def __init__(
+        self,
+        game_name: str,
+        players: set[Player] | None = None,
+        nicknames: dict[Player, Pseudo] | None = None,
+    ) -> None:
+        self.game_name = game_name
+        self.ids: set[Player] = players if players is not None else set()
+        if nicknames is not None:
+            nicknames = {
+                player: name for player, name in nicknames.items() if player in self.ids
+            }
+        self.nicknames: dict[Player, Pseudo] = (
+            nicknames if nicknames is not None else dict()
+        )
+        self._available_names = list(NICKNAMES - set(self.nicknames.values()))
+
+    def __len__(self) -> int:
+        return len(self.ids)
+
+    def __contains__(self, item: Player) -> bool:
+        return item in self.ids
+
+    def __iter__(self) -> Generator[Player, None, None]:
+        yield from self.ids
+
+    def generate_player_name(self) -> Player:
+        return Player(f"{self.game_name}_{utils.random.generate_random_identifier(16)}")
+
+    def pick_nickname(self) -> Pseudo:
+        if self._available_names:
+            nickname = random.choice(self._available_names)
+            self._available_names.remove(nickname)
+            return Pseudo(nickname)
+        else:
+            return random.choice(list(NICKNAMES))
+
+    def format(self) -> str:
+        nicknames = []
+        for player in self.ids:
+            nickname = self.get_nickname(player)
+            if nickname and str(nickname) != str(player):
+                nicknames.append(f"{player} ({nickname})")
+            else:
+                nicknames.append(player)
+        return ",".join(nicknames)
+
+    def add_nickname(self, player: Player, nickname: Pseudo) -> None:
+        if player not in self.ids:
+            pass
+        if (
+            player in self.nicknames
+            and (old_nickname := self.nicknames[player]) in NICKNAMES
+            and nickname != old_nickname
+        ):
+            # `old_nickname` is now available again
+            self._available_names.append(old_nickname)
+        self.nicknames[player] = nickname
+
+    def request_nickname(self, player: Player) -> Pseudo:
+        nickname = self.pick_nickname()
+        self.add_nickname(player, nickname)
+        return nickname
+
+    def remove_nickname(self, player: Player) -> None:
+        if player in self.nicknames:
+            old_nickname = self.nicknames[player]
+            del self.nicknames[player]
+            if old_nickname in NICKNAMES:
+                self._available_names.append(old_nickname)
+
+    def get_nickname(self, player: Player) -> Pseudo:
+        return self.nicknames.get(player, Pseudo(player))
+
+    def add_player(
+        self, player: Player | None = None, nickname: Pseudo | None = None
+    ) -> tuple[Player, Pseudo]:
+        if player is not None:
+            assert (
+                player not in _global_player_list and player not in self.ids
+            ), f"Player {player!r} already exists"
+        else:
+            player = self.generate_player_name()
+            # Do I need to check for collisions?
+        self.ids.add(player)
+        _global_player_list.add(player)
+        if nickname is None:
+            nickname = self.pick_nickname()
+        self.add_nickname(player, nickname)
+        return player, nickname
+
+    def remove_player(self, name: Player) -> None:
+        if name in _global_player_list:
+            _global_player_list.remove(name)
+        if name not in self.ids:
+            return
+        self.remove_nickname(name)
+        self.ids.remove(name)

--- a/amstramdam/game/types.py
+++ b/amstramdam/game/types.py
@@ -1,4 +1,3 @@
-
 from typing import (
     Optional,
     Any,
@@ -76,7 +75,7 @@ class GameMetrics(TypedDict):
 class GameParams(GameRunParams):
     n_run: int
     map: str
-    pseudos: dict[Player, Pseudo]
+    nicknames: dict[Player, Pseudo]
     wait_time: int
     difficulty: int
     is_public: bool

--- a/amstramdam/utils/__init__.py
+++ b/amstramdam/utils/__init__.py
@@ -1,1 +1,2 @@
 import amstramdam.utils.random as random
+import amstramdam.utils.nickname as nickname

--- a/amstramdam/utils/nickname.py
+++ b/amstramdam/utils/nickname.py
@@ -1,0 +1,17 @@
+from amstramdam.game.types import Pseudo
+
+
+MAX_LEN = 20
+
+
+def is_valid(name: str | None) -> bool:
+    """Return True if the candidate nickname is valid (i.e non-empty)"""
+    # TODO: implement checks?
+    return name is not None and len(str(name)) > 0
+
+
+def clean(name: str) -> Pseudo:
+    """Process the candidate nickname so that it meets our requirements"""
+    if len(name) > MAX_LEN + 3:
+        name = name[:MAX_LEN] + "..."
+    return Pseudo(name)

--- a/server.py
+++ b/server.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
                 force_name="__debug__",
             )
             for _ in range(3):
-                game.add_player(pseudo=None)
+                game.add_player(nickname=None)
             message += ", debug game created at https://localhost/game/__debug__"
 
         if check_loading:

--- a/tests/test_player_list.py
+++ b/tests/test_player_list.py
@@ -1,0 +1,34 @@
+from amstramdam.game import players as pl
+import pytest
+
+
+def test_player_list():
+    players = pl.PlayerList("test")
+    p1, n1 = players.add_player()
+    player_id = pl.Player("foo")
+    nickname = pl.Pseudo("foobar")
+    p2, n2 = players.add_player(player=player_id)
+    p3, n3 = players.add_player(nickname=nickname)
+    assert player_id in players
+    assert players.get_nickname(p2) == n2
+    with pytest.raises(Exception):
+        # Adding existing player should not be allowed
+        players.add_player(player=player_id)
+
+    alt_players = pl.PlayerList("alt")
+    with pytest.raises(Exception):
+        # Adding a player that exists in another list should not be allowed either
+        alt_players.add_player(player=p1)
+
+    assert n2 not in players._available_names
+    players.remove_player(p2)
+    assert n2 in players._available_names
+    players.remove_player(p3)
+    assert n3 not in players._available_names
+    new_n1 = players.request_nickname(p1)
+    assert new_n1 != n1
+    assert players.get_nickname(p1) == new_n1
+    assert not pl.PlayerList("test", nicknames={p1: n1}).nicknames
+    assert p1 in pl.PlayerList("foo", players={p1, p2})
+    assert p3 not in pl.PlayerList("foo", players={p1, p2})
+    assert n2 == pl.PlayerList("foo", players={p1}, nicknames={p1: n2}).get_nickname(p1)


### PR DESCRIPTION
`Game` is bloated (it handles the map, geometry, scores, leaderboard, nicknames). In this PR, we move all player management (add/remove player, update nicknames) to a new `PlayerList` class. `Game` has a new `players` attribute for its player list. Most of the former methods can be accessed through `game.players`. Methods `game.add/remove_player` still exist though, because some game-level setup/cleaning can be needed (e.g clear scores). I'm also on the process of getting rid of the ugly *pseudo* and replacing it by *nickname*. Later on, I may want to rename `Player` to `PlayerId`.