### PR TITLE
Fix issue with zoom and harshness

### DIFF
--- a/datasets.json
+++ b/datasets.json
@@ -125,8 +125,9 @@
         "col_lat": "lat",
         "col_group": "group",
         "tiles": "terrain",
+        "harshness": 0.65,
         "label*": ["Facile", "Normal", "Difficile"],
-        "weights*": [[1, 0.01], [1, 0.6, 0.1], [1, 1, 0.5]]
+        "weights*": [[1, 0.01], [1, 0.7, 0.1], [1, 1, 0.5]]
       },
       {
         "map_id": "aoc_fr",

--- a/front/map/map.vue
+++ b/front/map/map.vue
@@ -24,6 +24,7 @@ export default {
       tiles: LAYERS.bwSSL,
       isTerrain: false,
       precorrectionState: undefined,
+      maxZoom: 18,
     }
   },
 
@@ -35,11 +36,12 @@ export default {
     if (this.params.tiles === "terrain") {
       this.tiles = LAYERS.terrainSSL;
       this.isTerrain = true;
+      this.maxZoom = 9;
     }
     this.initialize("mapid", {
       allowZoom: true, // this.params.allow_zoom || this.isMobile,
       bounds: this.params.bbox,
-      maxZoom: canvas => (this.isMobile ? 18 : (canvas.getZoom() + 1)),
+      maxZoom: canvas => (this.isMobile ? this.maxZoom : Math.max(this.maxZoom, canvas.getZoom() + 1)),
       credits: this.isNarrow ? CREDITS_SHORT : CREDITS,
       tiles: this.tiles
     });
@@ -82,7 +84,7 @@ export default {
       this.precorrectionState = this.getMapState();
       // Allow unrestricted zoom during correction
       this.enableZoom();
-      this.canvas.setMaxZoom(18);
+      this.canvas.setMaxZoom(this.maxZoom);
       this.displayGameSummary(summary);
     },
 
@@ -285,7 +287,7 @@ export default {
       const refState = this.getMapState();
       // Disable zoom events (which allows us to unset max zoom)
       this.disableZoom();
-      this.canvas.setMaxZoom(18);
+      this.canvas.setMaxZoom(this.maxZoom);
       const bounds = answers.getBounds().pad(0.5);
       this.canvas.flyToBounds(bounds, {
         duration: constants.animations.map.duration});


### PR DESCRIPTION
- ESRI terrain map doesn't support zoom levels above 9, so we now set the `maxZoom` accordingly
- Increase difficulty of the Alps map by setting `harshness=0.65` instead of `0.7`