### PR TITLE
Fix dataset editor

### DIFF
--- a/amstramdam/datasets/dataframe.py
+++ b/amstramdam/datasets/dataframe.py
@@ -122,15 +122,14 @@ class DataFrameLoader(object):
         df = self.load(filename, persist=False)
         types = {col: df[col].dtype for col in df.columns}
         if created:
-            added = pd.DataFrame.from_records(
-                created, index=[o["pid"] for o in created]
-            )
-            added = added.astype(types)
+            added = pd.DataFrame.from_records(created)
+            added.index = added.pid
+            added = added.astype(types, errors="ignore")
             df = df.append(added, verify_integrity=True)
         for pid, changes in updated.items():
             parsed_pid = int(pid)
             for col, value in changes.items():
-                casted_value = np.array([value], dtype=types.get(col))
+                casted_value = np.array([value], dtype=types.get(col))[0]
                 df.loc[parsed_pid, col] = casted_value
         df = df.drop(columns=["pid"])
         return df

--- a/amstramdam/datasets/game_map.py
+++ b/amstramdam/datasets/game_map.py
@@ -89,7 +89,7 @@ class GameMap:
         )
 
     def jsonify_dataset(self) -> JsonifiedDataset:
-        records = list(self.df.to_records("records", renamed=False))
+        records = list(self.df.to_dict("records", renamed=False))
         return dict(
             dataset=self.name,
             points=records,

--- a/amstramdam/routes.py
+++ b/amstramdam/routes.py
@@ -63,7 +63,7 @@ def get_dataset_geometry(dataset):
 
 @app.route("/dataset/<dataset>")
 def get_edit_information(dataset):
-    data = dataloader.load(dataset).get_dataframe_as_json()
+    data = dataloader.load(dataset).jsonify_dataset()
     return jsonify(data)
 
 

--- a/front/datasetBuilder/datasetEditor.vue
+++ b/front/datasetBuilder/datasetEditor.vue
@@ -36,7 +36,7 @@
     </table>
     <div class="dataset-control">
       <button @click="createPoint">Nouveau</button>
-      <button @click="commitChanges">Enregistrer</button>
+      <button disabled @click="commitChanges">Enregistrer</button>
       <button @click="downloadChanges">Télécharger</button>
     </div>
   </div>
@@ -56,7 +56,7 @@ import constants from "../common/constants";
 import mapBaseMixin from "../map/mapBaseMixin.vue";
 import {GET, POST, unproxify} from "../common/utils.js";
 import MapSelector from "../lobby/mapSelector.vue";
-import {getIcon} from "../common/map.js";
+import {LAYERS, getIcon} from "../common/map.js";
 
 export default {
   components: {MapSelector},
@@ -93,7 +93,8 @@ export default {
       maxZoom: 18,
       extraCanvasParams: {
         zoomSnap: 0.1
-      }
+      },
+      tiles: LAYERS.labelled,
     });
 
     this.loadPoints(this.baseMap);
@@ -209,6 +210,7 @@ export default {
     },
 
     commitChanges() {
+      return;
       const changes = this.changes;
       changes["auth"] = this.authKey;
       POST(`/commit/${this.baseMap.map_id}`, changes);


### PR DESCRIPTION
This is a quick fix for the Editor. Editing datasets in place is still
not fixed, so the 'Save' button is disabled for now. Editing/adding
points to existing datasets is supported, but updated dataset must be
downloaded as CSV.