### PR TITLE
Reduce difficulty for Alps

### DIFF
--- a/data/france/alps.csv
+++ b/data/france/alps.csv
@@ -1,931 +1,934 @@
-,id,url,name,lon,lat,altitude,range,category,group,short_name,hint
-0,0.0,http://fr.dbpedia.org/resource/Col_de_Jambaz,Col de Jambaz,6.52028,46.2347,1027.0,Chablais,col,3,Col de Jambaz,Chablais
-1,1.0,http://fr.dbpedia.org/resource/Col_de_Gleize,Col de Gleize,6.04806,44.6222,1696.0,Dévoluy,col,3,Col de Gleize,Dévoluy
-2,2.0,http://fr.dbpedia.org/resource/Col_Infranchissable,Col Infranchissable,6.80833,45.8125,3349.0,Mont-Blanc,col,3,Col Infranchissable,Mont-Blanc
-3,3.0,http://fr.dbpedia.org/resource/Col_de_Miage,Col de Miage,6.81111,45.8244,3367.0,Mont-Blanc,col,3,Col de Miage,Mont-Blanc
-4,4.0,http://fr.dbpedia.org/resource/Col_de_Freissinières,Col de Freissinières,6.35361,44.7375,2782.0,Écrins,col,3,Col de Freissinières,Écrins
-5,5.0,http://fr.dbpedia.org/resource/Col_de_Mens,Col de Mens,5.77167,44.7603,1111.0,Dévoluy,col,3,Col de Mens,Dévoluy
-6,7.0,http://fr.dbpedia.org/resource/Col_de_Menée,Col de Menée,5.60361,44.7578,1457.0,Diois,col,3,Col de Menée,Diois
-7,8.0,http://fr.dbpedia.org/resource/Col_de_Palaquit,Col de Palaquit,5.76556,45.2728,1154.0,Chartreuse,col,3,Col de Palaquit,Chartreuse
-8,9.0,http://fr.dbpedia.org/resource/Col_de_la_Ramaz,Col de la Ramaz,6.57472,46.1633,1559.0,Chablais,col,3,Col de la Ramaz,Chablais
-9,10.0,http://fr.dbpedia.org/resource/Col_du_Feu,Col du Feu,6.50889,46.2944,1120.0,Chablais,col,3,Col du Feu,Chablais
-10,11.0,http://fr.dbpedia.org/resource/Col_du_Géant,Col du Géant,6.93472,45.8489,3365.0,Mont-Blanc,col,3,Col du Géant,Mont-Blanc
-11,12.0,http://fr.dbpedia.org/resource/Col_du_Pointu,Col du Pointu,5.35111,43.8356,499.0,Luberon,col,3,Col du Pointu,Luberon
-12,13.0,http://fr.dbpedia.org/resource/Col_Clapier,Col Clapier,6.92278,45.1669,2477.0,Mont-Cenis,col,3,Col Clapier,Mont-Cenis
-13,14.0,http://fr.dbpedia.org/resource/Col_de_Bornette,Col de Bornette,6.18528,45.7328,1304.0,Bauges,col,3,Col de Bornette,Bauges
-14,15.0,http://fr.dbpedia.org/resource/Col_de_la_Rochette_(Alpes),Col de la Rochette,5.29417,44.9778,1009.0,Vercors,col,3,Col de la Rochette,Vercors
-15,16.0,http://fr.dbpedia.org/resource/Col_des_Ayes,Col des Ayes,5.8425,45.3103,1538.0,Chartreuse,col,3,Col des Ayes,Chartreuse
-16,17.0,http://fr.dbpedia.org/resource/Col_du_Jandri,Col du Jandri,6.20306,44.9983,3150.0,Écrins,col,3,Col du Jandri,Écrins
-17,18.0,http://fr.dbpedia.org/resource/Golet_de_Doucy,Golet de Doucy,6.17722,45.7175,1329.0,Bauges,col,3,Golet de Doucy,Bauges
-18,19.0,http://fr.dbpedia.org/resource/Col_de_Leschaux,Col de Leschaux,6.13167,45.7719,897.0,Bauges,col,3,Col de Leschaux,Bauges
-19,20.0,http://fr.dbpedia.org/resource/Col_du_Grapillon,Col du Grapillon,5.84167,45.4628,1509.0,Chartreuse,col,3,Col du Grapillon,Chartreuse
-20,21.0,http://fr.dbpedia.org/resource/Col_Agnel,Col Agnel,6.9794,44.6842,2744.0,Escreins,col,3,Col Agnel,Escreins
-21,22.0,http://fr.dbpedia.org/resource/Col_d'Izoard,Col d'Izoard,6.73526,44.8196,2361.0,Queyras,col,0,Col d'Izoard,Queyras
-22,23.0,http://fr.dbpedia.org/resource/Col_de_l'Iseran,Col de l'Iseran,7.03146,45.4173,2764.0,Vanoise,col,0,Col de l'Iseran,Vanoise
-23,25.0,http://fr.dbpedia.org/resource/Col_de_la_Bonette,Col de la Bonette,6.807,44.327,2715.0,Mercantour,col,3,Col de la Bonette,Mercantour
-24,26.0,http://fr.dbpedia.org/resource/Col_d'Anterne,Col d'Anterne,6.79639,45.9803,2257.0,Giffre,col,3,Col d'Anterne,Giffre
-25,27.0,http://fr.dbpedia.org/resource/Col_du_Lautaret,Col du Lautaret,6.4055,45.0353,2058.0,Écrins,col,0,Col du Lautaret,Écrins
-26,29.0,http://fr.dbpedia.org/resource/Col_d'Èze,Col d'Èze,7.34667,43.7339,507.0,Préalpes de Nice,col,3,Col d'Èze,Préalpes de Nice
-27,30.0,http://fr.dbpedia.org/resource/Col_d'Allos,Col d'Allos,6.59417,44.2972,2247.0,Trois-Évêchés,col,1,Col d'Allos,Trois-Évêchés
-28,32.0,http://fr.dbpedia.org/resource/Col_de_Larche,Col de Larche,6.8985,44.4218,1194.0,Chambeyron,col,0,Col de Larche,Chambeyron
-29,34.0,http://fr.dbpedia.org/resource/Col_de_Montgenèvre,Col de Montgenèvre,6.72333,44.9308,1850.0,Queyras,col,0,Col de Montgenèvre,Queyras
-30,36.0,http://fr.dbpedia.org/resource/Col_de_Tende,Col de Tende,7.56197,44.1492,1871.0,Alpes ligures,col,0,Col de Tende,Alpes ligures
-31,38.0,http://fr.dbpedia.org/resource/Col_de_Vars,Col de Vars,6.70278,44.5392,2108.0,Parpaillon,col,0,Col de Vars,Parpaillon
-32,40.0,http://fr.dbpedia.org/resource/Col_de_la_Cayolle,Col de la Cayolle,6.74389,44.2589,2326.0,Pelat,col,3,Col de la Cayolle,Pelat
-33,42.0,http://fr.dbpedia.org/resource/Col_du_Parpaillon,Col du Parpaillon,6.64611,44.4883,2783.0,Parpaillon,col,2,Col du Parpaillon,Parpaillon
-34,43.0,http://fr.dbpedia.org/resource/Cormet_de_Roselend,Cormet de Roselend,6.69065,45.6912,1968.0,Mont-Blanc,col,3,Cormet de Roselend,Mont-Blanc
-35,45.0,http://fr.dbpedia.org/resource/Col_de_la_Leisse,Col de la Leisse,6.90806,45.4247,2761.0,Vanoise,col,3,Col de la Leisse,Vanoise
-36,46.0,http://fr.dbpedia.org/resource/Col_de_Moissière,Col de Moissière,6.2204,44.6014,1571.0,Écrins,col,3,Col de Moissière,Écrins
-37,47.0,http://fr.dbpedia.org/resource/Col_de_Cou_(Vallée_Verte),Col de Cou (Vallée Verte),6.45444,46.2622,1117.0,Chablais,col,3,Col de Cou,Chablais
-38,48.0,http://fr.dbpedia.org/resource/Col_de_Foron,Col de Foron,6.59,46.1811,1832.0,Chablais,col,3,Col de Foron,Chablais
-39,49.0,http://fr.dbpedia.org/resource/Col_de_Terramont,Col de Terramont,6.49056,46.2469,1096.0,Chablais,col,3,Col de Terramont,Chablais
-40,50.0,http://fr.dbpedia.org/resource/Col_de_Vence_(Isère),Col de Vence (Isère),5.75083,45.2358,782.0,Chartreuse,col,3,Col de Vence,Chartreuse
-41,51.0,http://fr.dbpedia.org/resource/Col_des_Robines,Col des Robines,6.49333,43.9614,988.0,Trois-Évêchés,col,3,Col des Robines,Trois-Évêchés
-42,53.0,http://fr.dbpedia.org/resource/Col_des_Grandes_Jorasses,Col des Grandes Jorasses,6.97389,45.8678,3825.0,Mont-Blanc,col,3,Col des Grandes Jorasses,Mont-Blanc
-43,54.0,http://fr.dbpedia.org/resource/Col_de_Corobin,Col de Corobin,6.32024,44.0079,1230.0,Trois-Évêchés,col,3,Col de Corobin,Trois-Évêchés
-44,55.0,http://fr.dbpedia.org/resource/Col_de_Luens,Col de Luens,6.5873,43.8186,1054.0,Préalpes de Castellane,col,3,Col de Luens,Préalpes de Castellane
-45,56.0,http://fr.dbpedia.org/resource/Col_de_Montfuron,Col de Montfuron,5.6975,43.8442,649.0,Luberon,col,1,Col de Montfuron,Luberon
-46,57.0,http://fr.dbpedia.org/resource/Col_du_Pilon,Col du Pilon,6.88291,43.6852,780.0,Préalpes de Castellane,col,3,Col du Pilon,Préalpes de Castellane
-47,58.0,http://fr.dbpedia.org/resource/Pas_de_la_Faye,Pas de la Faye,6.8376,43.7114,981.0,Préalpes de Castellane,col,3,Pas de la Faye,Préalpes de Castellane
-48,59.0,http://fr.dbpedia.org/resource/Col_de_la_Placette,Col de la Placette,5.65833,45.3297,587.0,Chartreuse,col,3,Col de la Placette,Chartreuse
-49,61.0,http://fr.dbpedia.org/resource/Col_des_Égaux,Col des Égaux,5.81167,45.4442,958.0,Chartreuse,col,3,Col des Égaux,Chartreuse
-50,62.0,http://fr.dbpedia.org/resource/Col_du_Bonhomme_(Alpes),Col du Bonhomme (Alpes),6.70667,45.735,2329.0,Mont-Blanc,col,3,Col du Bonhomme,Mont-Blanc
-51,64.0,http://fr.dbpedia.org/resource/Col_du_Corbier,Col du Corbier,6.64444,46.2836,1237.0,Chablais,col,3,Col du Corbier,Chablais
-52,65.0,http://fr.dbpedia.org/resource/Col_du_Mollard,Col du Mollard,6.33667,45.2103,1630.0,Arves,col,3,Col du Mollard,Arves
-53,66.0,http://fr.dbpedia.org/resource/Col_d'Ey,Col d'Ey,5.27778,44.3128,718.0,Baronnies,col,3,Col d'Ey,Baronnies
-54,67.0,http://fr.dbpedia.org/resource/Col_de_la_Ponsonnière,Col de la Ponsonnière,6.4661,45.0547,2613.0,Cerces,col,3,Col de la Ponsonnière,Cerces
-55,68.0,http://fr.dbpedia.org/resource/Col_des_Aravis,Col des Aravis,6.46472,45.8725,1486.0,Aravis,col,0,Col des Aravis,Aravis
-56,69.0,http://fr.dbpedia.org/resource/Col_du_Petit-Saint-Bernard,Col du Petit-Saint-Bernard,6.88395,45.6803,2188.0,Mont-Blanc,col,0,Col du Petit-Saint-Bernard,Mont-Blanc
-57,71.0,http://fr.dbpedia.org/resource/Col_de_la_Colombière,Col de la Colombière,6.47556,45.9922,1613.0,Bornes,col,3,Col de la Colombière,Bornes
-58,72.0,http://fr.dbpedia.org/resource/Col_de_Granon,Col de Granon,6.61111,44.9628,2413.0,Cerces,col,3,Col de Granon,Cerces
-59,73.0,http://fr.dbpedia.org/resource/Col_de_Joux_Plane,Col de Joux Plane,6.71278,46.1297,1691.0,Chablais,col,0,Col de Joux Plane,Chablais
-60,74.0,http://fr.dbpedia.org/resource/Col_de_Manse,Col de Manse,6.13176,44.6115,1269.0,Écrins,col,3,Col de Manse,Écrins
-61,75.0,http://fr.dbpedia.org/resource/Col_de_Vence_(Alpes-Maritimes),Col de Vence,7.07528,43.7606,962.0,Préalpes de Castellane,col,0,Col de Vence,Préalpes de Castellane
-62,76.0,http://fr.dbpedia.org/resource/Col_de_l'Échelle,Col de l'Échelle,6.6569,45.0264,1762.0,Cerces,col,2,Col de l'Échelle,Cerces
-63,77.0,http://fr.dbpedia.org/resource/Col_du_Fau,Col du Fau,5.62606,44.9062,899.0,Vercors,col,3,Col du Fau,Vercors
-64,78.0,http://fr.dbpedia.org/resource/Col_du_Festre,Col du Festre,5.85843,44.6671,1442.0,Dévoluy,col,3,Col du Festre,Dévoluy
-65,79.0,http://fr.dbpedia.org/resource/Col_du_Noyer,Col du Noyer,5.98519,44.6919,1664.0,Dévoluy,col,3,Col du Noyer,Dévoluy
-66,80.0,http://fr.dbpedia.org/resource/Col_de_Murs,Col de Murs,5.22639,43.9767,627.0,Monts de Vaucluse,col,3,Col de Murs,Monts de Vaucluse
-67,81.0,http://fr.dbpedia.org/resource/Col_de_Restefond,Col de Restefond,6.80861,44.3364,2680.0,Mercantour,col,3,Col de Restefond,Mercantour
-68,82.0,http://fr.dbpedia.org/resource/Col_de_Turini,Col de Turini,7.3917,43.9778,1604.0,Préalpes de Nice,col,0,Col de Turini,Préalpes de Nice
-69,83.0,http://fr.dbpedia.org/resource/Col_de_Valante,Col de Valante,7.07,44.68,2815.0,Alpes cottiennes,col,1,Col de Valante,Alpes cottiennes
-70,84.0,http://fr.dbpedia.org/resource/Col_de_la_Lombarde,Col de la Lombarde,7.15,44.2028,2351.0,Mercantour,col,2,Col de la Lombarde,Mercantour
-71,85.0,http://fr.dbpedia.org/resource/Col_de_la_Machine,Col de la Machine,5.33389,44.9761,1011.0,Vercors,col,3,Col de la Machine,Vercors
-72,86.0,http://fr.dbpedia.org/resource/Col_des_Champs,Col des Champs,6.70139,44.1781,2089.0,Pelat,col,3,Col des Champs,Pelat
-73,87.0,http://fr.dbpedia.org/resource/Col_des_Moises,Col des Moises,6.46694,46.2775,1121.0,Chablais,col,3,Col des Moises,Chablais
-74,88.0,http://fr.dbpedia.org/resource/Faux_col_de_Restefond,Faux col de Restefond,6.80139,44.3369,2656.0,Mercantour,col,3,Faux col de Restefond,Mercantour
-75,89.0,http://fr.dbpedia.org/resource/Col_de_Balme,Col de Balme,6.96944,46.0272,2191.0,Mont-Blanc,col,3,Col de Balme,Mont-Blanc
-76,90.0,http://fr.dbpedia.org/resource/Col_de_Cerise,Col de Cerise,7.28417,44.1417,2543.0,Mercantour,col,3,Col de Cerise,Mercantour
-77,91.0,http://fr.dbpedia.org/resource/Col_de_Fenestre,Col de Fenestre,7.36083,44.1161,2474.0,Mercantour,col,2,Col de Fenestre,Mercantour
-78,92.0,http://fr.dbpedia.org/resource/Col_de_la_Pisse,Col de la Pisse,6.17944,44.7125,2354.0,Écrins,col,3,Col de la Pisse,Écrins
-79,93.0,http://fr.dbpedia.org/resource/Col_du_Viallet,Col du Viallet,6.15861,44.705,2240.0,Écrins,col,3,Col du Viallet,Écrins
-80,94.0,http://fr.dbpedia.org/resource/Col_d'Urine,Col d'Urine,7.00444,44.7939,2525.0,Alpes cottiennes,col,3,Col d'Urine,Alpes cottiennes
-81,95.0,http://fr.dbpedia.org/resource/Col_de_Romme,Col de Romme,6.57389,46.03,1297.0,Aravis,col,3,Col de Romme,Aravis
-82,96.0,http://fr.dbpedia.org/resource/Col_de_la_Cluse,Col de la Cluse,5.85917,45.4539,1169.0,Chartreuse,col,3,Col de la Cluse,Chartreuse
-83,98.0,http://fr.dbpedia.org/resource/Col_de_la_Colle-Saint-Michel,Col de la Colle-Saint-Michel,6.59333,44.0467,1431.0,Préalpes de Castellane,col,3,Col de la Colle-Saint-Michel,Préalpes de Castellane
-84,99.0,http://fr.dbpedia.org/resource/Col_d'Ambin,Col d'Ambin,6.88,45.1347,2899.0,Mont-Cenis,col,3,Col d'Ambin,Mont-Cenis
-85,100.0,http://fr.dbpedia.org/resource/Col_de_la_Ruchère,Col de la Ruchère,5.79806,45.3864,1407.0,Chartreuse,col,3,Col de la Ruchère,Chartreuse
-86,101.0,http://fr.dbpedia.org/resource/Col_du_Petit_Mont-Cenis,Col du Petit Mont-Cenis,6.86528,45.2106,2183.0,Mont-Cenis,col,3,Col du Petit Mont-Cenis,Mont-Cenis
-87,102.0,http://fr.dbpedia.org/resource/Col_Saint-Martin,Col Saint-Martin,7.22139,44.0708,1503.0,Mercantour,col,3,Col Saint-Martin,Mercantour
-88,103.0,http://fr.dbpedia.org/resource/Col_de_Braus,Col de Braus,7.39889,43.8728,1002.0,Préalpes de Nice,col,3,Col de Braus,Préalpes de Nice
-89,104.0,http://fr.dbpedia.org/resource/Col_de_Castillon,Col de Castillon,7.46083,43.8392,728.0,Préalpes de Nice,col,3,Col de Castillon,Préalpes de Nice
-90,105.0,http://fr.dbpedia.org/resource/Col_de_Cou_(Barme),Col de Cou (Barme),6.79306,46.15,1921.0,Chablais,col,3,Col de Cou,Chablais
-91,106.0,http://fr.dbpedia.org/resource/Col_de_Mary,Col de Mary,6.88639,44.5522,2641.0,Chambeyron,col,3,Col de Mary,Chambeyron
-92,107.0,http://fr.dbpedia.org/resource/Col_de_la_Couillole,Col de la Couillole,7.02278,44.1,1678.0,Mercantour,col,3,Col de la Couillole,Mercantour
-93,108.0,http://fr.dbpedia.org/resource/Col_des_Gets,Col des Gets,6.66667,46.1569,1170.0,Chablais,col,3,Col des Gets,Chablais
-94,110.0,http://fr.dbpedia.org/resource/Col_de_Porte_(Isère),Col de Porte,5.76722,45.2894,1326.0,Chartreuse,col,3,Col de Porte,Chartreuse
-95,111.0,http://fr.dbpedia.org/resource/Col_de_la_Seigne,Col de la Seigne,6.80722,45.7514,2516.0,Mont-Blanc,col,3,Col de la Seigne,Mont-Blanc
-96,112.0,http://fr.dbpedia.org/resource/Col_des_Saisies,Col des Saisies,6.52861,45.7583,1633.0,Beaufortain,col,0,Col des Saisies,Beaufortain
-97,113.0,http://fr.dbpedia.org/resource/Col_Bayard,Col Bayard,6.08134,44.6128,1248.0,Écrins,col,3,Col Bayard,Écrins
-98,115.0,http://fr.dbpedia.org/resource/Col_de_Grimone,Col de Grimone,5.65397,44.6917,1318.0,Diois,col,3,Col de Grimone,Diois
-99,116.0,http://fr.dbpedia.org/resource/Col_de_Rousset,Col de Rousset,5.406,44.8406,1254.0,Vercors,col,0,Col de Rousset,Vercors
-100,117.0,http://fr.dbpedia.org/resource/Col_de_la_Bataille_(Vercors),Col de la Bataille,5.23197,44.8974,1313.0,Vercors,col,3,Col de la Bataille,Vercors
-101,118.0,http://fr.dbpedia.org/resource/Col_de_la_Charmette,Col de la Charmette,5.7401,45.3219,1261.0,Chartreuse,col,3,Col de la Charmette,Chartreuse
-102,119.0,http://fr.dbpedia.org/resource/Col_de_la_Croix-de-Fer,Col de la Croix-de-Fer,6.20373,45.2278,2068.0,Grandes Rousses,col,0,Col de la Croix-de-Fer,Grandes Rousses
-103,121.0,http://fr.dbpedia.org/resource/Col_de_la_Madeleine,Col de la Madeleine,6.37556,45.4353,1993.0,Vanoise,col,0,Col de la Madeleine,Vanoise
-104,123.0,http://fr.dbpedia.org/resource/Col_des_Montets,Col des Montets,6.92335,46.0035,1461.0,Mont-Blanc,col,3,Col des Montets,Mont-Blanc
-105,125.0,http://fr.dbpedia.org/resource/Col_du_Coq,Col du Coq,5.83663,45.3025,1434.0,Chartreuse,col,3,Col du Coq,Chartreuse
-106,126.0,http://fr.dbpedia.org/resource/Col_du_Cucheron,Col du Cucheron,5.83445,45.3654,1139.0,Chartreuse,col,3,Col du Cucheron,Chartreuse
-107,127.0,http://fr.dbpedia.org/resource/Col_du_Glandon,Col du Glandon,6.1758,45.2394,1924.0,Arves,col,1,Col du Glandon,Arves
-108,129.0,http://fr.dbpedia.org/resource/Col_du_Granier,Col du Granier,5.91515,45.4806,1134.0,Chartreuse,col,3,Col du Granier,Chartreuse
-109,130.0,http://fr.dbpedia.org/resource/Col_du_Labouret,Col du Labouret,6.37056,44.2492,1240.0,Trois-Évêchés,col,1,Col du Labouret,Trois-Évêchés
-110,131.0,http://fr.dbpedia.org/resource/Col_du_Mont-Cenis,Col du Mont-Cenis,6.9009,45.2602,2081.0,Mont-Cenis,col,3,Col du Mont-Cenis,Mont-Cenis
-111,132.0,http://fr.dbpedia.org/resource/Col_du_Télégraphe,Col du Télégraphe,6.44531,45.2025,1566.0,Cerces,col,1,Col du Télégraphe,Cerces
-112,133.0,http://fr.dbpedia.org/resource/Col_de_la_Vanoise,Col de la Vanoise,6.795,45.3903,2522.0,Vanoise,col,1,Col de la Vanoise,Vanoise
-113,134.0,http://fr.dbpedia.org/resource/Col_du_Longet,Col du Longet,6.95361,44.6431,2647.0,Chambeyron,col,3,Col du Longet,Chambeyron
-114,136.0,http://fr.dbpedia.org/resource/Col_de_Chavière,Col de Chavière,6.65722,45.2706,2796.0,Vanoise,col,3,Col de Chavière,Vanoise
-115,137.0,http://fr.dbpedia.org/resource/Col_de_l'Émeindras,Col de l'Émeindras,5.80389,45.2833,1372.0,Chartreuse,col,3,Col de l'Émeindras,Chartreuse
-116,138.0,http://fr.dbpedia.org/resource/Col_de_la_Mort_d'Imbert,Col de la Mort d'Imbert,5.77889,43.8633,591.0,Luberon,col,3,Col de la Mort d'Imbert,Luberon
-117,139.0,http://fr.dbpedia.org/resource/Col_du_Lausfer,Col du Lausfer,7.09083,44.2217,2430.0,Mercantour,col,3,Col du Lausfer,Mercantour
-118,140.0,http://fr.dbpedia.org/resource/Pas_du_Préfouns,Pas du Préfouns,7.23139,44.1708,2615.0,Mercantour,col,3,Pas du Préfouns,Mercantour
-119,141.0,http://fr.dbpedia.org/resource/Col_de_Marcieu,Col de Marcieu,5.91879,45.3559,1065.0,Chartreuse,col,3,Col de Marcieu,Chartreuse
-120,142.0,http://fr.dbpedia.org/resource/Col_de_Pelouse,Col de Pelouse,6.74861,45.1422,2793.0,Mont-Cenis,col,3,Col de Pelouse,Mont-Cenis
-121,143.0,http://fr.dbpedia.org/resource/Col_du_Fréjus,Col du Fréjus,6.67389,45.1306,2540.0,Mont-Cenis,col,3,Col du Fréjus,Mont-Cenis
-122,144.0,http://fr.dbpedia.org/resource/Col_de_Font-Belle,Col de Font-Belle,6.14722,44.2153,1304.0,Préalpes de Digne,col,3,Col de Font-Belle,Préalpes de Digne
-123,145.0,http://fr.dbpedia.org/resource/Col_de_Sarenne,Col de Sarenne,6.14917,45.0874,1999.0,Grandes Rousses,col,3,Col de Sarenne,Grandes Rousses
-124,146.0,http://fr.dbpedia.org/resource/Col_du_Fanget,Col du Fanget,6.3275,44.3278,1459.0,Préalpes de Digne,col,3,Col du Fanget,Préalpes de Digne
-125,147.0,http://fr.dbpedia.org/resource/Col_de_Clavel,Col de Clavel,6.63,43.7497,1069.0,Préalpes de Castellane,col,3,Col de Clavel,Préalpes de Castellane
-126,148.0,http://fr.dbpedia.org/resource/Col_de_Pennes,Col de Pennes,5.3425,44.6447,1040.0,Diois,col,3,Col de Pennes,Diois
-127,149.0,http://fr.dbpedia.org/resource/Col_de_l'Alpe,Col de l'Alpe,5.92806,45.4169,1793.0,Chartreuse,col,3,Col de l'Alpe,Chartreuse
-128,150.0,http://fr.dbpedia.org/resource/Col_de_l'Alpette,Col de l'Alpette,5.91889,45.4419,1547.0,Chartreuse,col,3,Col de l'Alpette,Chartreuse
-129,151.0,http://fr.dbpedia.org/resource/Col_des_Prés,Col des Prés,6.06111,45.5958,1135.0,Bauges,col,3,Col des Prés,Bauges
-130,152.0,http://fr.dbpedia.org/resource/Col_du_Joly,Col du Joly,6.67389,45.7839,1989.0,Beaufortain,col,3,Col du Joly,Beaufortain
-131,153.0,http://fr.dbpedia.org/resource/Col_de_Tamié,Col de Tamié,6.30861,45.6728,907.0,Bauges,col,3,Col de Tamié,Bauges
-132,154.0,http://fr.dbpedia.org/resource/Col_de_l'Épine_(Haute-Savoie),Col de l'Épine,6.34889,45.7792,947.0,Aravis,col,3,Col de l'Épine,Aravis
-133,155.0,http://fr.dbpedia.org/resource/Col_de_la_Croix_Fry,Col de la Croix Fry,6.40472,45.8767,1467.0,Aravis,col,3,Col de la Croix Fry,Aravis
-134,156.0,http://fr.dbpedia.org/resource/Col_de_la_Forclaz_(Haute-Savoie),Col de la Forclaz (Haute-Savoie),6.24472,45.8083,1157.0,Bornes,col,2,Col de la Forclaz,Bornes
-135,157.0,http://fr.dbpedia.org/resource/Col_de_la_Perche_(Savoie),Col de la Perche,6.21139,45.4281,1984.0,Belledonne,col,3,Col de la Perche,Belledonne
-136,158.0,http://fr.dbpedia.org/resource/Col_Luitel,Col Luitel,5.84889,45.0875,1262.0,Belledonne,col,3,Col Luitel,Belledonne
-137,159.0,http://fr.dbpedia.org/resource/Col_de_Macuègne,Col de Macuègne,5.51,44.1819,1068.0,Monts de Vaucluse,col,3,Col de Macuègne,Monts de Vaucluse
-138,161.0,http://fr.dbpedia.org/resource/Col_de_la_Doria,Col de la Doria,5.98917,45.6068,1110.0,Bauges,col,3,Col de la Doria,Bauges
-139,162.0,http://fr.dbpedia.org/resource/Col_de_la_Rousse,Col de la Rousse,6.44333,44.4683,2147.0,Parpaillon,col,3,Col de la Rousse,Parpaillon
-140,163.0,http://fr.dbpedia.org/resource/Pas_de_l'Âne,Pas de l'Âne,6.49278,45.6808,2371.0,Beaufortain,col,3,Pas de l'Âne,Beaufortain
-141,164.0,http://fr.dbpedia.org/resource/Col_de_Rabou,Col de Rabou,5.98139,44.6417,1888.0,Dévoluy,col,3,Col de Rabou,Dévoluy
-142,165.0,http://fr.dbpedia.org/resource/Col_des_Granons,Col des Granons,5.68,43.8642,489.0,Luberon,col,3,Col des Granons,Luberon
-143,167.0,http://fr.dbpedia.org/resource/Col_du_Mollard_(Chartreuse),Col du Mollard (Chartreuse),5.86722,45.4836,1320.0,Chartreuse,col,3,Col du Mollard,Chartreuse
-144,168.0,http://fr.dbpedia.org/resource/Col_de_Bovinant,Col de Bovinant,5.81389,45.3847,1646.0,Chartreuse,col,2,Col de Bovinant,Chartreuse
-145,169.0,http://fr.dbpedia.org/resource/Col_de_Léchaud,Col de Léchaud,5.80889,45.3872,1704.0,Chartreuse,col,3,Col de Léchaud,Chartreuse
-146,170.0,http://fr.dbpedia.org/resource/Col_du_Frêt,Col du Frêt,5.81917,45.3867,1750.0,Chartreuse,col,3,Col du Frêt,Chartreuse
-147,171.0,http://fr.dbpedia.org/resource/Col_de_Bassachaux,Col de Bassachaux,6.77222,46.2222,1778.0,Chablais,col,3,Col de Bassachaux,Chablais
-148,172.0,http://fr.dbpedia.org/resource/Pas_de_Morgins,Pas de Morgins,6.84611,46.2494,1371.0,Chablais,col,3,Pas de Morgins,Chablais
-149,173.0,http://fr.dbpedia.org/resource/Col_Saint-Roch,Col Saint-Roch,7.33833,43.8958,991.0,Préalpes de Nice,col,3,Col Saint-Roch,Préalpes de Nice
-150,174.0,http://fr.dbpedia.org/resource/Col_de_Cabre_(Alpes),Col de Cabre,5.59833,44.5494,1180.0,Diois,col,3,Col de Cabre,Diois
-151,175.0,http://fr.dbpedia.org/resource/Col_de_Chavan,Col de Chavan,6.55944,46.1772,1745.0,Chablais,col,3,Col de Chavan,Chablais
-152,176.0,http://fr.dbpedia.org/resource/Col_de_Châteauneuf_de_Contes,Col de Châteauneuf de Contes,7.29306,43.8003,627.0,Préalpes de Nice,col,3,Col de Châteauneuf de Contes,Préalpes de Nice
-153,177.0,http://fr.dbpedia.org/resource/Col_de_Vésinaz,Col de Vésinaz,6.575,46.1758,1802.0,Chablais,col,3,Col de Vésinaz,Chablais
-154,178.0,http://fr.dbpedia.org/resource/Col_des_Arces,Col des Arces,6.49222,46.2683,1163.0,Chablais,col,3,Col des Arces,Chablais
-155,179.0,http://fr.dbpedia.org/resource/Col_de_Bretolet,Col de Bretolet,6.79611,46.1425,1936.0,Chablais,col,3,Col de Bretolet,Chablais
-156,180.0,http://fr.dbpedia.org/resource/Col_des_Limouches,Col des Limouches,5.15833,44.8869,1086.0,Vercors,col,3,Col des Limouches,Vercors
-157,181.0,http://fr.dbpedia.org/resource/Col_du_Grand_Cucheron,Col du Grand Cucheron,6.248,45.49,1188.0,Belledonne,col,3,Col du Grand Cucheron,Belledonne
-158,182.0,http://fr.dbpedia.org/resource/Col_des_Lèques,Col des Lèques,6.46389,43.8656,1146.0,Préalpes de Digne,col,2,Col des Lèques,Préalpes de Digne
-159,183.0,http://fr.dbpedia.org/resource/Col_de_Carri,Col de Carri,5.3625,44.9442,1202.0,Vercors,col,3,Col de Carri,Vercors
-160,184.0,http://fr.dbpedia.org/resource/Col_de_Proncel,Col de Proncel,5.38194,44.9281,1100.0,Vercors,col,3,Col de Proncel,Vercors
-161,185.0,http://fr.dbpedia.org/resource/Col_de_Romeyère,Col de Romeyère,5.47972,45.1436,1069.0,Vercors,col,3,Col de Romeyère,Vercors
-162,186.0,http://fr.dbpedia.org/resource/Col_de_Saint-Alexis,Col de Saint-Alexis,5.40722,44.8722,1222.0,Vercors,col,3,Col de Saint-Alexis,Vercors
-163,187.0,http://fr.dbpedia.org/resource/Col_de_Tourniol,Col de Tourniol,5.18444,44.9189,1145.0,Vercors,col,3,Col de Tourniol,Vercors
-164,188.0,http://fr.dbpedia.org/resource/Col_de_l'Allimas,Col de l'Allimas,5.56694,44.8819,1352.0,Vercors,col,3,Col de l'Allimas,Vercors
-165,189.0,http://fr.dbpedia.org/resource/Col_de_l'Arzelier,Col de l'Arzelier,5.59556,44.9911,1154.0,Vercors,col,3,Col de l'Arzelier,Vercors
-166,190.0,http://fr.dbpedia.org/resource/Col_de_la_Chau,Col de la Chau,5.35667,44.9072,1337.0,Vercors,col,3,Col de la Chau,Vercors
-167,191.0,http://fr.dbpedia.org/resource/Col_de_la_Croix-Perrin,Col de la Croix-Perrin,5.55972,45.13,1218.0,Vercors,col,3,Col de la Croix-Perrin,Vercors
-168,192.0,http://fr.dbpedia.org/resource/Col_de_la_Portette,Col de la Portette,5.29472,44.9567,1175.0,Vercors,col,3,Col de la Portette,Vercors
-169,193.0,http://fr.dbpedia.org/resource/Col_Lacroix,Col Lacroix,7.02328,44.7645,2298.0,Alpes cottiennes,col,3,Col Lacroix,Alpes cottiennes
-170,194.0,http://fr.dbpedia.org/resource/Col_du_Chaussy,Col du Chaussy,6.35647,45.3438,1533.0,Vanoise,col,3,Col du Chaussy,Vanoise
-171,195.0,http://fr.dbpedia.org/resource/Col_de_Couz,Col de Couz,5.81722,45.4692,624.0,"",col,3,Col de Couz,""
-172,196.0,http://fr.dbpedia.org/resource/Col_du_Galibier,Col du Galibier,6.40862,45.0643,2642.0,"",col,0,Col du Galibier,""
-173,197.0,http://fr.dbpedia.org/resource/Col_de_la_Croix-Haute,Col de la Croix-Haute,5.67755,44.7248,1176.0,"",col,3,Col de la Croix-Haute,""
-174,198.0,http://fr.dbpedia.org/resource/Col_d'Ornon,Col d'Ornon,5.96757,45.0088,1367.0,"",col,2,Col d'Ornon,""
-175,200.0,http://fr.dbpedia.org/resource/Hirmentaz,Hirmentaz,6.495,46.2297,1607.0,Chablais,ski,2,Hirmentaz,
-176,201.0,http://fr.dbpedia.org/resource/Semnoz,Semnoz,6.10472,45.7972,1699.0,Bauges,ski,0,Semnoz,
-177,203.0,http://fr.dbpedia.org/resource/Auris,Auris,6.0875,45.0472,1240.0,"",ski,3,Auris,
-178,204.0,http://fr.dbpedia.org/resource/Saint-Pierre-de-Chartreuse,Saint-Pierre-de-Chartreuse,5.81611,45.3433,900.0,"",ski,0,Saint-Pierre-de-Chartreuse,
-179,205.0,http://fr.dbpedia.org/resource/La_Ruchère,La Ruchère,5.79694,45.4092,1165.0,"",ski,0,La Ruchère,
-180,207.0,http://fr.dbpedia.org/resource/Méribel,Méribel,6.56627,45.3967,1026.0,Vanoise,ski,0,Méribel,
-181,208.0,http://fr.dbpedia.org/resource/Les_Menuires,Les Menuires,6.5375,45.3244,1850.0,Vanoise,ski,0,Les Menuires,
-182,209.0,http://fr.dbpedia.org/resource/Chamrousse,Chamrousse,5.87444,45.1092,1700.0,Belledonne,ski,0,Chamrousse,
-183,213.0,http://fr.dbpedia.org/resource/Val_Thorens,Val Thorens,6.57972,45.2983,2300.0,Vanoise,ski,0,Val Thorens,
-184,214.0,http://fr.dbpedia.org/resource/Les_Deux_Alpes,Les Deux Alpes,6.12539,45.0115,1650.0,Écrins,ski,0,Les Deux Alpes,
-185,215.0,http://fr.dbpedia.org/resource/Les_Saisies,Les Saisies,6.54178,45.7564,990.0,Beaufortain,ski,2,Les Saisies,
-186,216.0,http://fr.dbpedia.org/resource/Désert_d'Entremont,Désert d'Entremont,5.86556,45.4631,1200.0,Chartreuse,ski,2,Désert d'Entremont,
-187,217.0,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.42583,45.9722,1000.0,Aravis,ski,3,Le Grand-Bornand,
-188,218.0,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.45074,45.9722,1000.0,Aravis,ski,3,Le Grand-Bornand,
-189,219.0,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.42583,45.9425,1000.0,Aravis,ski,0,Le Grand-Bornand,
-190,220.0,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.45074,45.9425,1000.0,Aravis,ski,3,Le Grand-Bornand,
-191,221.0,http://fr.dbpedia.org/resource/Auris-en-Oisans_(station),Auris-en-Oisans,6.07806,45.0558,1600.0,Alpes du Nord,ski,2,Auris-en-Oisans,
-192,222.0,http://fr.dbpedia.org/resource/Courchevel,Courchevel,6.63474,45.4159,1110.0,Vanoise,ski,0,Courchevel,
-193,223.0,http://fr.dbpedia.org/resource/L'Alpe_d'Huez,L'Alpe d'Huez,6.07139,45.0936,1850.0,Grandes Rousses,ski,0,L'Alpe d'Huez,
-194,224.0,http://fr.dbpedia.org/resource/Bernex_(Haute-Savoie),Bernex,6.6758,46.3608,900.0,Chablais,ski,2,Bernex,
-195,225.0,http://fr.dbpedia.org/resource/Peisey-Vallandry,Peisey-Vallandry,6.75694,45.5472,1600.0,Vanoise,ski,2,Peisey-Vallandry,
-196,226.0,http://fr.dbpedia.org/resource/Aussois,Aussois,6.74233,45.2272,1500.0,Vanoise,ski,2,Aussois,
-197,227.0,http://fr.dbpedia.org/resource/Fontcouverte-la-Toussuire,Fontcouverte-la-Toussuire,6.30306,45.2472,1700.0,Arvan-Villards,ski,1,Fontcouverte-la-Toussuire,
-198,228.0,http://fr.dbpedia.org/resource/Les_Arcs_(Savoie),Les Arcs (Savoie),6.8077,45.5716,813.0,Vanoise,ski,0,Les Arcs,
-199,229.0,http://fr.dbpedia.org/resource/Orelle,Orelle,6.53778,45.21,890.0,Vanoise,ski,2,Orelle,
-200,230.0,http://fr.dbpedia.org/resource/Saint-Colomban-des-Villards,Saint-Colomban-des-Villards,6.22722,45.295,1100.0,Belledonne,ski,2,Saint-Colomban-des-Villards,
-201,231.0,http://fr.dbpedia.org/resource/Valfréjus,Valfréjus,6.65342,45.174,1550.0,Cerces,ski,1,Valfréjus,
-202,232.0,http://fr.dbpedia.org/resource/Les_Karellis,Les Karellis,6.40331,45.2288,1600.0,Maurienne,ski,1,Les Karellis,
-203,233.0,http://fr.dbpedia.org/resource/Valmorel,Valmorel,6.4425,45.4619,1320.0,Vanoise,ski,1,Valmorel,
-204,234.0,http://fr.dbpedia.org/resource/La_Norma,La Norma,6.69889,45.2022,1350.0,Maurienne,ski,1,La Norma,
-205,235.0,http://fr.dbpedia.org/resource/Les_Aillons-Margériaz,Les Aillons-Margériaz,6.06231,45.6429,1000.0,Bauges,ski,0,Les Aillons-Margériaz,
-206,236.0,http://fr.dbpedia.org/resource/Praz_de_Lys_-_Sommand,Praz de Lys - Sommand,6.5906,46.147,1500.0,Chablais,ski,2,Praz de Lys - Sommand,
-207,237.0,http://fr.dbpedia.org/resource/La_Plagne,La Plagne,6.67722,45.5064,0.0,Vanoise,ski,0,La Plagne,
-208,238.0,http://fr.dbpedia.org/resource/Paradiski,Paradiski,6.75934,45.5459,0.0,Vanoise,ski,3,Paradiski,
-209,240.0,http://fr.dbpedia.org/resource/Les_Trois_Vallées,Les Trois Vallées,6.5733,45.3647,0.0,Vanoise,ski,3,Les Trois Vallées,
-210,242.0,http://fr.dbpedia.org/resource/Méaudre,Méaudre,5.52778,45.1278,0.0,Vercors,ski,2,Méaudre,
-211,243.0,http://fr.dbpedia.org/resource/Domaine_skiable_de_Villard-de-Lans_Corrençon-en-Vercors,Domaine skiable de Villard-de-Lans Corrençon-en-Vercors,5.55672,45.0471,0.0,Vercors,ski,4,Domaine skiable de Villard-de-Lans Corrençon-en-Vercors,
-212,244.0,http://fr.dbpedia.org/resource/Portes_du_Soleil,Portes du Soleil,6.77333,46.1937,0.0,Chablais,ski,3,Portes du Soleil,
-213,246.0,http://fr.dbpedia.org/resource/Espace_Killy,Espace Killy,6.77089,45.6194,0.0,Alpes du Nord,ski,3,Espace Killy,
-214,248.0,http://fr.dbpedia.org/resource/Les_Sept_Laux,Les Sept Laux,5.9931,45.2557,0.0,Belledonne,ski,0,Les Sept Laux,
-215,249.0,http://fr.dbpedia.org/resource/Les_Carroz_d'Arâches,Les Carroz d'Arâches,6.64361,46.025,0.0,Alpes,ski,0,Les Carroz d'Arâches,
-216,250.0,http://fr.dbpedia.org/resource/Alpe_du_Grand_Serre,Alpe du Grand Serre,5.86222,45.0239,0.0,Taillefer,ski,2,Alpe du Grand Serre,
-217,251.0,http://fr.dbpedia.org/resource/Arêches-Beaufort,Arêches-Beaufort,6.6346,45.4113,0.0,Beaufortain,ski,2,Arêches-Beaufort,
-218,252.0,http://fr.dbpedia.org/resource/La_Sambuy-Seythenex,La Sambuy-Seythenex,6.27525,45.7132,1150.0,"",ski,2,La Sambuy-Seythenex,
-219,253.0,http://fr.dbpedia.org/resource/Évasion_Mont-Blanc,Évasion Mont-Blanc,6.68175,45.8293,1000.0,"",ski,3,Évasion Mont-Blanc,
-220,254.0,http://fr.dbpedia.org/resource/Espace_Diamant,Espace Diamant,6.5542,45.7945,990.0,"",ski,3,Espace Diamant,
-221,255.0,http://fr.dbpedia.org/resource/Valloire,Valloire,6.42917,45.1658,1430.0,"",ski,0,Valloire,
-222,256.0,http://fr.dbpedia.org/resource/Val-d'Isère,Val-d'Isère,6.97806,45.4506,1850.0,"",ski,0,Val-d'Isère,
-223,257.0,http://fr.dbpedia.org/resource/La_Clusaz,La Clusaz,6.42389,45.905,1040.0,"",ski,0,La Clusaz,
-224,258.0,http://fr.dbpedia.org/resource/Avoriaz,Avoriaz,6.76853,46.1945,1800.0,"",ski,0,Avoriaz,
-225,259.0,http://fr.dbpedia.org/resource/Saint-Martin-de-Belleville,Saint-Martin-de-Belleville,6.50528,45.3811,1450.0,"",ski,1,Saint-Martin-de-Belleville,
-226,260.0,http://fr.dbpedia.org/resource/Les_Sybelles,Les Sybelles,6.29036,45.2365,1100.0,"",ski,3,Les Sybelles,
-227,261.0,http://fr.dbpedia.org/resource/La_Rosière_(Montvalezan),La Rosière (Montvalezan),6.84793,45.6288,1850.0,"",ski,3,La Rosière,
-228,262.0,http://fr.dbpedia.org/resource/Les_Bottières,Les Bottières,6.29748,45.2667,1300.0,"",ski,3,Les Bottières,
-229,263.0,http://fr.dbpedia.org/resource/Châtel,Châtel,6.84167,46.2675,1183.0,"",ski,2,Châtel,
-230,264.0,http://fr.dbpedia.org/resource/Gresse-en-Vercors,Gresse-en-Vercors,5.5675,44.9031,1250.0,"",ski,0,Gresse-en-Vercors,
-231,265.0,http://fr.dbpedia.org/resource/Manigod,Manigod,6.37056,45.8617,1500.0,"",ski,1,Manigod,
-232,266.0,http://fr.dbpedia.org/resource/Saint-Jean-de-Sixt,Saint-Jean-de-Sixt,6.41056,45.9239,963.0,"",ski,0,Saint-Jean-de-Sixt,
-233,267.0,http://fr.dbpedia.org/resource/Tignes,Tignes,6.91389,45.4733,2100.0,"",ski,0,Tignes,
-234,268.0,http://fr.dbpedia.org/resource/La_Chèvrerie_(Haute-Savoie),La Chèvrerie (Haute-Savoie),6.57083,46.2122,1100.0,"",ski,2,La Chèvrerie,
-235,269.0,http://fr.dbpedia.org/resource/La_Grande-Terche,La Grande-Terche,6.63417,46.2142,950.0,"",ski,3,La Grande-Terche,
-236,270.0,http://fr.dbpedia.org/resource/Le_Corbier,Le Corbier,6.28333,45.25,1550.0,"",ski,3,Le Corbier,
-237,271.0,http://fr.dbpedia.org/resource/Saint-François-Longchamp,Saint-François-Longchamp,6.34917,45.4106,1650.0,"",ski,2,Saint-François-Longchamp,
-238,272.0,http://fr.dbpedia.org/resource/Saint-Jean-d'Arves,Saint-Jean-d'Arves,6.27389,45.2081,1550.0,"",ski,2,Saint-Jean-d'Arves,
-239,273.0,http://fr.dbpedia.org/resource/Saint-Sorlin-d'Arves,Saint-Sorlin-d'Arves,6.23083,45.2205,1550.0,"",ski,2,Saint-Sorlin-d'Arves,
-240,274.0,http://fr.dbpedia.org/resource/Sainte-Foy-Tarentaise,Sainte-Foy-Tarentaise,6.88444,45.59,813.0,"",ski,2,Sainte-Foy-Tarentaise,
-241,275.0,http://fr.dbpedia.org/resource/Savoie_Grand_Revard,Savoie Grand Revard,5.97824,45.682,1350.0,"",ski,0,Savoie Grand Revard,
-242,276.0,http://fr.dbpedia.org/resource/La_Tania,La Tania,6.59522,45.4317,1400.0,"",ski,2,La Tania,
-243,277.0,http://fr.dbpedia.org/resource/Passy_Plaine-Joux,Passy Plaine-Joux,6.74015,45.9508,1360.0,"",ski,2,Passy Plaine-Joux,
-244,278.0,http://fr.dbpedia.org/resource/Flumet,Flumet,6.5175,45.8203,0.0,"",ski,1,Flumet,
-245,279.0,http://fr.dbpedia.org/resource/Chamonix-Mont-Blanc,Chamonix-Mont-Blanc,6.86972,45.9231,0.0,"",ski,0,Chamonix-Mont-Blanc,
-246,280.0,http://fr.dbpedia.org/resource/Lans-en-Vercors,Lans-en-Vercors,5.58917,45.1292,0.0,"",ski,1,Lans-en-Vercors,
-247,281.0,http://fr.dbpedia.org/resource/Oz_(Isère),Oz (Isère),6.0511,45.1406,0.0,"",ski,2,Oz,
-248,282.0,http://fr.dbpedia.org/resource/Peisey-Nancroix,Peisey-Nancroix,6.75694,45.5472,0.0,"",ski,2,Peisey-Nancroix,
-249,283.0,http://fr.dbpedia.org/resource/Saint-Hilaire_(Isère),Saint-Hilaire (Isère),5.8875,45.3108,0.0,"",ski,2,Saint-Hilaire,
-250,284.0,http://fr.dbpedia.org/resource/Bessans,Bessans,7.0,45.32,0.0,"",ski,2,Bessans,
-251,285.0,http://fr.dbpedia.org/resource/Champagny-en-Vanoise,Champagny-en-Vanoise,6.69333,45.4553,0.0,"",ski,2,Champagny-en-Vanoise,
-252,286.0,http://fr.dbpedia.org/resource/Lanslebourg-Mont-Cenis,Lanslebourg-Mont-Cenis,6.88,45.2864,0.0,"",ski,2,Lanslebourg-Mont-Cenis,
-253,287.0,http://fr.dbpedia.org/resource/Orange_(station_de_sports_d'hiver),Orange (station de sports d'hiver),6.32533,46.0274,0.0,"",ski,3,Orange,
-254,288.0,http://fr.dbpedia.org/resource/Samoëns,Samoëns,6.72806,46.0847,0.0,"",ski,1,Samoëns,
-255,289.0,http://fr.dbpedia.org/resource/Albiez-Montrond,Albiez-Montrond,6.34139,45.2206,0.0,"",ski,2,Albiez-Montrond,
-256,290.0,http://fr.dbpedia.org/resource/Autrans,Autrans,5.54278,45.1758,0.0,"",ski,0,Autrans,
-257,291.0,http://fr.dbpedia.org/resource/Allevard,Allevard,6.07472,45.3944,0.0,"",ski,2,Allevard,
-258,292.0,http://fr.dbpedia.org/resource/Beaufort_(Savoie),Beaufort,6.57556,45.7189,0.0,"",ski,0,Beaufort,
-259,293.0,http://fr.dbpedia.org/resource/Bramans,Bramans,6.77639,45.2244,0.0,"",ski,2,Bramans,
-260,294.0,http://fr.dbpedia.org/resource/Abondance_(Haute-Savoie),Abondance,6.72278,46.2797,0.0,"",ski,0,Abondance,
-261,295.0,http://fr.dbpedia.org/resource/Combloux,Combloux,6.64167,45.8964,0.0,"",ski,2,Combloux,
-262,296.0,http://fr.dbpedia.org/resource/Cordon_(Haute-Savoie),Cordon (Haute-Savoie),6.61278,45.9239,0.0,"",ski,2,Cordon,
-263,297.0,http://fr.dbpedia.org/resource/Corrençon-en-Vercors,Corrençon-en-Vercors,5.52694,45.0322,0.0,"",ski,1,Corrençon-en-Vercors,
-264,298.0,http://fr.dbpedia.org/resource/La_Chapelle-d'Abondance,La Chapelle-d'Abondance,6.78806,46.2961,0.0,"",ski,1,La Chapelle-d'Abondance,
-265,299.0,http://fr.dbpedia.org/resource/La_Giettaz,La Giettaz,6.49583,45.8631,0.0,"",ski,2,La Giettaz,
-266,300.0,http://fr.dbpedia.org/resource/Le_Reposoir,Le Reposoir,6.53583,46.0119,0.0,"",ski,2,Le Reposoir,
-267,301.0,http://fr.dbpedia.org/resource/Les_Gets,Les Gets,6.67083,46.1606,0.0,"",ski,2,Les Gets,
-268,302.0,http://fr.dbpedia.org/resource/Mont-Saxonnex,Mont-Saxonnex,6.485,46.0547,0.0,"",ski,2,Mont-Saxonnex,
-269,303.0,http://fr.dbpedia.org/resource/Praz-sur-Arly,Praz-sur-Arly,6.57083,45.8381,0.0,"",ski,2,Praz-sur-Arly,
-270,304.0,http://fr.dbpedia.org/resource/Sixt-Fer-à-Cheval,Sixt-Fer-à-Cheval,6.77639,46.0558,0.0,"",ski,2,Sixt-Fer-à-Cheval,
-271,305.0,http://fr.dbpedia.org/resource/Thollon-les-Mémises,Thollon-les-Mémises,6.69972,46.3889,0.0,"",ski,2,Thollon-les-Mémises,
-272,306.0,http://fr.dbpedia.org/resource/Vallorcine,Vallorcine,6.93389,46.0353,0.0,"",ski,1,Vallorcine,
-273,307.0,http://fr.dbpedia.org/resource/Verchaix,Verchaix,6.67694,46.0972,0.0,"",ski,2,Verchaix,
-274,308.0,http://fr.dbpedia.org/resource/La_Féclaz,La Féclaz,5.98305,45.6452,0.0,"",ski,0,La Féclaz,
-275,309.0,http://fr.dbpedia.org/resource/Morillon_(Haute-Savoie),Morillon,6.6775,46.0833,0.0,"",ski,2,Morillon,
-276,310.0,http://fr.dbpedia.org/resource/Galibier-Thabor,Galibier-Thabor,6.42917,45.1658,0.0,"",ski,3,Galibier-Thabor,
-277,311.0,http://fr.dbpedia.org/resource/Villard-de-Lans,Villard-de-Lans,5.55139,45.0708,0.0,"",ski,0,Villard-de-Lans,
-278,312.0,http://fr.dbpedia.org/resource/Habère-Poche,Habère-Poche,6.47333,46.2497,0.0,"",ski,3,Habère-Poche,
-279,313.0,http://fr.dbpedia.org/resource/Linga_-_Pré_La_Joux,Linga - Pré La Joux,6.83833,46.2814,0.0,"",ski,2,Linga - Pré La Joux,
-280,314.0,http://fr.dbpedia.org/resource/Argentière,Argentière,6.921515464782715,45.97567094185704,0.0,"",ski,0,Argentière,
-281,315.0,http://fr.dbpedia.org/resource/Bonneval-sur-Arc,Bonneval-sur-Arc,7.04722,45.3722,0.0,"",ski,1,Bonneval-sur-Arc,
-282,316.0,http://fr.dbpedia.org/resource/Brides-les-Bains,Brides-les-Bains,6.5675,45.4533,0.0,"",ski,2,Brides-les-Bains,
-283,317.0,http://fr.dbpedia.org/resource/Crest-Voland,Crest-Voland,6.50639,45.7958,0.0,"",ski,2,Crest-Voland,
-284,318.0,http://fr.dbpedia.org/resource/Hauteluce,Hauteluce,6.58639,45.7519,0.0,"",ski,2,Hauteluce,
-285,319.0,http://fr.dbpedia.org/resource/Notre-Dame-de-Bellecombe,Notre-Dame-de-Bellecombe,6.51972,45.8103,0.0,"",ski,2,Notre-Dame-de-Bellecombe,
-286,320.0,http://fr.dbpedia.org/resource/Pralognan-la-Vanoise,Pralognan-la-Vanoise,6.72222,45.3825,0.0,"",ski,2,Pralognan-la-Vanoise,
-287,321.0,http://fr.dbpedia.org/resource/Valmeinier,Valmeinier,6.48194,45.1847,0.0,"",ski,2,Valmeinier,
-288,322.0,http://fr.dbpedia.org/resource/La_Léchère,La Léchère,6.47417,45.5331,0.0,"",ski,2,La Léchère,
-289,323.0,http://fr.dbpedia.org/resource/Val_Cenis_Vanoise,Val Cenis,6.894,45.286,0.0,"",ski,0,Val Cenis Vanoise,
-290,324.0,http://fr.dbpedia.org/resource/Super-Châtel,Super-Châtel,6.83833,46.2814,0.0,"",ski,3,Super-Châtel,
-291,325.0,http://fr.dbpedia.org/resource/Les_Brasses,Les Brasses,6.449,46.168,0.0,"",ski,1,Les Brasses,
-292,326.0,http://fr.dbpedia.org/resource/Aiguille_des_Grands_Charmoz,Aiguille des Grands Charmoz,6.91889,45.9044,3445.0,Aiguilles de Chamonix,sommet,4,Aiguille des Grands Charmoz,Aiguilles de Chamonix
-293,327.0,http://fr.dbpedia.org/resource/Aiguille_des_Grands_Montets,Aiguille des Grands Montets,6.96056,45.9481,3295.0,Mont-Blanc,sommet,4,Aiguille des Grands Montets,Mont-Blanc
-294,328.0,http://fr.dbpedia.org/resource/Aiguille_du_Belvédère,Aiguille du Belvédère,6.87333,45.9875,2965.0,Aiguilles Rouges,sommet,4,Aiguille du Belvédère,Aiguilles Rouges
-295,329.0,http://fr.dbpedia.org/resource/Chapeau_de_Gendarme_(montagne),Chapeau de Gendarme,6.665,44.3372,2682.0,Mercantour,sommet,4,Chapeau de Gendarme,Mercantour
-296,330.0,http://fr.dbpedia.org/resource/Dômes_de_Miage,Dômes de Miage,6.8,45.8158,3673.0,Mont-Blanc,sommet,4,Dômes de Miage,Mont-Blanc
-297,331.0,http://fr.dbpedia.org/resource/Grand_Cheval_de_Bois,Grand Cheval de Bois,6.63333,44.2919,2838.0,Pelat,sommet,4,Grand Cheval de Bois,Pelat
-298,332.0,http://fr.dbpedia.org/resource/Grande_Bosse,Grande Bosse,6.85583,45.8353,4513.0,Mont-Blanc,sommet,4,Grande Bosse,Mont-Blanc
-299,334.0,http://fr.dbpedia.org/resource/Mont_Billiat,Mont Billiat,6.58389,46.2883,1894.0,Chablais,sommet,4,Mont Billiat,Chablais
-300,335.0,http://fr.dbpedia.org/resource/Montagne_de_Céüse,Montagne de Céüse,5.96167,44.5086,2016.0,Bochaine,sommet,1,Montagne de Céüse,Bochaine
-301,336.0,http://fr.dbpedia.org/resource/Petite_Bosse,Petite Bosse,6.85472,45.8361,4547.0,Mont-Blanc,sommet,4,Petite Bosse,Mont-Blanc
-302,337.0,http://fr.dbpedia.org/resource/Pointe_de_Marcelly,Pointe de Marcelly,6.57528,46.1286,1999.0,Chablais,sommet,4,Pointe de Marcelly,Chablais
-303,338.0,http://fr.dbpedia.org/resource/Pointe_des_Cerces,Pointe des Cerces,6.4876,45.0658,3097.0,Cerces,sommet,0,Pointe des Cerces,Cerces
-304,339.0,http://fr.dbpedia.org/resource/Trélod,Trélod,6.19639,45.6928,2181.0,Bauges,sommet,4,Trélod,Bauges
-305,340.0,http://fr.dbpedia.org/resource/Étale_(sommet),Étale (sommet),6.4475,45.85,2484.0,Aravis,sommet,4,Étale,Aravis
-306,341.0,http://fr.dbpedia.org/resource/Bric_de_Rubren,Bric de Rubren,6.94972,44.6197,3340.0,Chambeyron,sommet,4,Bric de Rubren,Chambeyron
-307,342.0,http://fr.dbpedia.org/resource/Cime_de_la_Lombarde,Cime de la Lombarde,7.16306,44.2083,2800.0,Mercantour,sommet,4,Cime de la Lombarde,Mercantour
-308,343.0,http://fr.dbpedia.org/resource/Cimet,Cimet,6.70417,44.2906,3020.0,Pelat,sommet,4,Cimet,Pelat
-309,344.0,http://fr.dbpedia.org/resource/Grand_Armet,Grand Armet,5.93444,44.9811,2792.0,Taillefer,sommet,4,Grand Armet,Taillefer
-310,345.0,http://fr.dbpedia.org/resource/Grand_Aréa,Grand Aréa,6.57278,44.98,2869.0,Cerces,sommet,4,Grand Aréa,Cerces
-311,346.0,http://fr.dbpedia.org/resource/Grand_Capucin,Grand Capucin,6.89806,45.8517,3838.0,Mont-Blanc,sommet,4,Grand Capucin,Mont-Blanc
-312,347.0,http://fr.dbpedia.org/resource/Les_Droites,Les Droites,6.98917,45.9303,4000.0,Mont-Blanc,sommet,4,Les Droites,Mont-Blanc
-313,348.0,http://fr.dbpedia.org/resource/Mont_Veyrier,Mont Veyrier,6.1825,45.9006,1291.0,Bornes,sommet,4,Mont Veyrier,Bornes
-314,349.0,http://fr.dbpedia.org/resource/Pointe-Basse_de_Mary,Pointe-Basse de Mary,6.88972,44.5828,3126.0,Chambeyron,sommet,4,Pointe-Basse de Mary,Chambeyron
-315,350.0,http://fr.dbpedia.org/resource/Pointe-Haute_de_Mary,Pointe-Haute de Mary,6.89472,44.5753,3206.0,Chambeyron,sommet,4,Pointe-Haute de Mary,Chambeyron
-316,351.0,http://fr.dbpedia.org/resource/Cousson,Cousson,6.24,44.0536,1516.0,Trois-Évêchés,sommet,4,Cousson,Trois-Évêchés
-317,352.0,http://fr.dbpedia.org/resource/Grenier_de_Commune,Grenier de Commune,6.83306,46.0456,2775.0,Giffre,sommet,4,Grenier de Commune,Giffre
-318,353.0,http://fr.dbpedia.org/resource/Lancebranlette,Lancebranlette,6.85611,45.6853,2936.0,Mont-Blanc,sommet,4,Lancebranlette,Mont-Blanc
-319,354.0,http://fr.dbpedia.org/resource/Pain_de_Sucre_(Queyras),Pain de Sucre,6.99639,44.6903,3208.0,Escreins,sommet,0,Pain de Sucre,Escreins
-320,355.0,http://fr.dbpedia.org/resource/Pic_de_Morgon,Pic de Morgon,6.3975,44.4917,2324.0,Parpaillon,sommet,1,Pic de Morgon,Parpaillon
-321,356.0,http://fr.dbpedia.org/resource/Pointe_de_Tierce,Pointe de Tierce,7.01306,45.3083,2973.0,Alpes grées,sommet,4,Pointe de Tierce,Alpes grées
-322,357.0,http://fr.dbpedia.org/resource/Tête_de_Vautisse,Tête de Vautisse,6.48528,44.7011,3156.0,Écrins,sommet,0,Tête de Vautisse,Écrins
-323,358.0,http://fr.dbpedia.org/resource/Tête_du_Rouget,Tête du Rouget,6.26333,44.955,3418.0,Écrins,sommet,4,Tête du Rouget,Écrins
-324,359.0,http://fr.dbpedia.org/resource/Grand_Charnier_d'Allemond,Grand Charnier d'Allemond,5.99667,45.155,2777.0,Belledonne,sommet,4,Grand Charnier d'Allemond,Belledonne
-325,360.0,http://fr.dbpedia.org/resource/Le_Pavé,Le Pavé,6.32389,44.9986,3823.0,Écrins,sommet,4,Le Pavé,Écrins
-326,361.0,http://fr.dbpedia.org/resource/Pointe_inférieure_du_Tricot,Pointe inférieure du Tricot,6.7825,45.8461,2830.0,Mont-Blanc,sommet,4,Pointe inférieure du Tricot,Mont-Blanc
-327,362.0,http://fr.dbpedia.org/resource/Baou_de_Saint-Jeannet,Baou de Saint-Jeannet,7.13806,43.7506,802.0,Préalpes de Grasse,sommet,4,Baou de Saint-Jeannet,Préalpes de Grasse
-328,363.0,http://fr.dbpedia.org/resource/Corne_au_Taureau,Corne au Taureau,6.80944,46.1272,2630.0,Giffre,sommet,4,Corne au Taureau,Giffre
-329,364.0,http://fr.dbpedia.org/resource/La_Grande_Pointe,La Grande Pointe,6.58972,46.2181,1802.0,Chablais,sommet,4,La Grande Pointe,Chablais
-330,365.0,http://fr.dbpedia.org/resource/Le_Cheval_Blanc_(sommet),Le Cheval Blanc (sommet),6.87278,46.0519,2831.0,Giffre,sommet,4,Le Cheval Blanc,Giffre
-331,366.0,http://fr.dbpedia.org/resource/Mont_Chauffé,Mont Chauffé,6.76056,46.3094,2093.0,Chablais,sommet,4,Mont Chauffé,Chablais
-332,367.0,http://fr.dbpedia.org/resource/Palastre,Palastre,6.20889,44.6931,2278.0,Écrins,sommet,4,Palastre,Écrins
-333,368.0,http://fr.dbpedia.org/resource/Petit_Pinier,Petit Pinier,6.40556,44.7061,3100.0,Écrins,sommet,4,Petit Pinier,Écrins
-334,369.0,http://fr.dbpedia.org/resource/Pic_de_Tenneverge,Pic de Tenneverge,6.87944,46.0942,2989.0,Giffre,sommet,4,Pic de Tenneverge,Giffre
-335,370.0,http://fr.dbpedia.org/resource/Pointe_Rousse,Pointe Rousse,6.7925,46.0972,2577.0,Giffre,sommet,4,Pointe Rousse,Giffre
-336,371.0,http://fr.dbpedia.org/resource/Pointe_d'Anterne,Pointe d'Anterne,6.78528,45.9797,2733.0,Giffre,sommet,4,Pointe d'Anterne,Giffre
-337,372.0,http://fr.dbpedia.org/resource/Pointe_de_Nyon,Pointe de Nyon,6.72194,46.1467,2019.0,Giffre,sommet,4,Pointe de Nyon,Giffre
-338,373.0,http://fr.dbpedia.org/resource/Pointe_de_la_Masse,Pointe de la Masse,6.5093,45.2971,2804.0,Vanoise,sommet,4,Pointe de la Masse,Vanoise
-339,374.0,http://fr.dbpedia.org/resource/Roche_Bernaude,Roche Bernaude,6.62656,45.103,3225.0,Mont-Cenis,sommet,4,Roche Bernaude,Mont-Cenis
-340,375.0,http://fr.dbpedia.org/resource/Serre_de_l'Aup,Serre de l'Aup,5.24361,44.6608,1195.0,Diois,sommet,1,Serre de l'Aup,Diois
-341,376.0,http://fr.dbpedia.org/resource/Tête_de_Bostan,Tête de Bostan,6.8,46.1356,2406.0,Giffre,sommet,4,Tête de Bostan,Giffre
-342,377.0,http://fr.dbpedia.org/resource/Tête_du_Colonney,Tête du Colonney,6.69083,45.9714,2692.0,Faucigny,sommet,4,Tête du Colonney,Faucigny
-343,378.0,http://fr.dbpedia.org/resource/Aiguille_de_Triolet,Aiguille de Triolet,7.02444,45.9164,3870.0,Mont-Blanc,sommet,4,Aiguille de Triolet,Mont-Blanc
-344,379.0,http://fr.dbpedia.org/resource/Aiguille_des_Glaciers,Aiguille des Glaciers,6.8025,45.7786,3816.0,Mont-Blanc,sommet,4,Aiguille des Glaciers,Mont-Blanc
-345,380.0,http://fr.dbpedia.org/resource/Aiguille_du_Tour,Aiguille du Tour,7.00944,45.9942,3542.0,Mont-Blanc,sommet,4,Aiguille du Tour,Mont-Blanc
-346,381.0,http://fr.dbpedia.org/resource/Aiguillette_du_Lauzet,Aiguillette du Lauzet,6.48333,45.0214,2717.0,Cerces,sommet,4,Aiguillette du Lauzet,Cerces
-347,382.0,http://fr.dbpedia.org/resource/Mont_Pouzenc,Mont Pouzenc,6.51583,44.4586,2898.0,Parpaillon,sommet,4,Mont Pouzenc,Parpaillon
-348,383.0,http://fr.dbpedia.org/resource/Montagne_de_la_Loube,Montagne de la Loube,5.99222,43.3689,830.0,Sainte-Baume,sommet,4,Montagne de la Loube,Sainte-Baume
-349,384.0,http://fr.dbpedia.org/resource/Aiguille_de_l'A_Neuve,Aiguille de l'A Neuve,7.03667,45.9522,3753.0,Mont-Blanc,sommet,4,Aiguille de l'A Neuve,Mont-Blanc
-350,385.0,http://fr.dbpedia.org/resource/Bec_Charvet,Bec Charvet,5.82861,45.2964,1738.0,Chartreuse,sommet,4,Bec Charvet,Chartreuse
-351,386.0,http://fr.dbpedia.org/resource/Mont_Julioz,Mont Julioz,6.16056,45.7072,1662.0,Bauges,sommet,4,Mont Julioz,Bauges
-352,387.0,http://fr.dbpedia.org/resource/Mont_Neiglier,Mont Neiglier,7.38694,44.0883,2786.0,Mercantour,sommet,4,Mont Neiglier,Mercantour
-353,388.0,http://fr.dbpedia.org/resource/Roc_d'Arguille,Roc d'Arguille,5.8375,45.3169,1768.0,Chartreuse,sommet,4,Roc d'Arguille,Chartreuse
-354,389.0,http://fr.dbpedia.org/resource/Roc_des_Bœufs,Roc des Bœufs,6.16611,45.7542,1774.0,Bauges,sommet,4,Roc des Bœufs,Bauges
-355,390.0,http://fr.dbpedia.org/resource/Pointe_Noire_de_Pormenaz,Pointe Noire de Pormenaz,6.80111,45.9583,2323.0,Pormenaz,sommet,4,Pointe Noire de Pormenaz,Pormenaz
-356,391.0,http://fr.dbpedia.org/resource/Pointe_de_Thivelet,Pointe de Thivelet,5.82194,45.4347,1231.0,Chartreuse,sommet,4,Pointe de Thivelet,Chartreuse
-357,392.0,http://fr.dbpedia.org/resource/Dent_du_Vélan,Dent du Vélan,6.77486,46.3472,2059.0,Chablais,sommet,4,Dent du Vélan,Chablais
-358,393.0,http://fr.dbpedia.org/resource/Mont_Giusalet,Mont Giusalet,6.92972,45.1806,3312.0,Mont-Cenis,sommet,4,Mont Giusalet,Mont-Cenis
-359,394.0,http://fr.dbpedia.org/resource/Pic_de_Caramantran,Pic de Caramantran,6.96333,44.6783,3025.0,Escreins,sommet,4,Pic de Caramantran,Escreins
-360,395.0,http://fr.dbpedia.org/resource/Pointe_de_la_Terrasse_(Giffre),Pointe de la Terrasse (Giffre),6.89222,46.0417,2734.0,Giffre,sommet,4,Pointe de la Terrasse,Giffre
-361,396.0,http://fr.dbpedia.org/resource/Pointe_du_Lamet,Pointe du Lamet,6.99889,45.2394,3504.0,Mont-Cenis,sommet,4,Pointe du Lamet,Mont-Cenis
-362,397.0,http://fr.dbpedia.org/resource/Aiguille_du_Tacul,Aiguille du Tacul,6.96111,45.8847,3444.0,Mont-Blanc,sommet,4,Aiguille du Tacul,Mont-Blanc
-363,398.0,http://fr.dbpedia.org/resource/Aiguilles_de_Pelens,Aiguilles de Pelens,6.71639,44.1425,2523.0,Pelat,sommet,4,Aiguilles de Pelens,Pelat
-364,399.0,http://fr.dbpedia.org/resource/Cime_de_Frémamorte,Cime de Frémamorte,7.25056,44.1569,2730.0,Mercantour,sommet,4,Cime de Frémamorte,Mercantour
-365,400.0,http://fr.dbpedia.org/resource/La_Cochette,La Cochette,5.83556,45.4553,1618.0,Chartreuse,sommet,4,La Cochette,Chartreuse
-366,401.0,http://fr.dbpedia.org/resource/La_Scia,La Scia,5.85083,45.3489,1791.0,Chartreuse,sommet,4,La Scia,Chartreuse
-367,402.0,http://fr.dbpedia.org/resource/Pointe_Giegn,Pointe Giegn,7.22361,44.1633,2888.0,Mercantour,sommet,4,Pointe Giegn,Mercantour
-368,403.0,http://fr.dbpedia.org/resource/Roche_Méane,Roche Méane,6.33528,44.9703,3712.0,Écrins,sommet,4,Roche Méane,Écrins
-369,404.0,http://fr.dbpedia.org/resource/Roche_du_Chardonnet,Roche du Chardonnet,6.54889,45.1019,2950.0,Cerces,sommet,4,Roche du Chardonnet,Cerces
-370,405.0,http://fr.dbpedia.org/resource/Rocher_de_la_Grande_Tempête,Rocher de la Grande Tempête,6.55861,45.0803,3002.0,Cerces,sommet,4,Rocher de la Grande Tempête,Cerces
-371,406.0,http://fr.dbpedia.org/resource/Aiguille_du_Midi,Aiguille du Midi,6.88722,45.8786,3842.0,Mont-Blanc,sommet,0,Aiguille du Midi,Mont-Blanc
-372,407.0,http://fr.dbpedia.org/resource/Cime_de_la_Bonette,Cime de la Bonette,6.80694,44.3217,2860.0,Mercantour,sommet,4,Cime de la Bonette,Mercantour
-373,408.0,http://fr.dbpedia.org/resource/Dôme_du_Goûter,Dôme du Goûter,6.84333,45.8428,4304.0,Mont-Blanc,sommet,1,Dôme du Goûter,Mont-Blanc
-374,409.0,http://fr.dbpedia.org/resource/Le_Môle,Le Môle,6.455,46.1067,1863.0,Chablais,sommet,4,Le Môle,Chablais
-375,411.0,http://fr.dbpedia.org/resource/Aiguilles_d'Arves,Aiguilles d'Arves,6.33444,45.1231,3514.0,Arves,sommet,0,Aiguilles d'Arves,Arves
-376,412.0,http://fr.dbpedia.org/resource/Barre_des_Écrins,Barre des Écrins,6.35944,44.9219,4102.0,Écrins,sommet,4,Barre des Écrins,Écrins
-377,413.0,http://fr.dbpedia.org/resource/Cornettes_de_Bise,Cornettes de Bise,6.78444,46.3325,2432.0,Chablais,sommet,4,Cornettes de Bise,Chablais
-378,414.0,http://fr.dbpedia.org/resource/Dent_de_Crolles,Dent de Crolles,5.85528,45.3083,2062.0,Chartreuse,sommet,0,Dent de Crolles,Chartreuse
-379,415.0,http://fr.dbpedia.org/resource/Mont_Pourri,Mont Pourri,6.86,45.5283,3779.0,Vanoise,sommet,0,Mont Pourri,Vanoise
-380,416.0,http://fr.dbpedia.org/resource/Montagne_de_Lure,Montagne de Lure,5.80278,44.1233,1826.0,Monts de Vaucluse,sommet,0,Montagne de Lure,Monts de Vaucluse
-381,417.0,http://fr.dbpedia.org/resource/Roc_d'Enfer,Roc d'Enfer,6.61028,46.1894,2244.0,Chablais,sommet,4,Roc d'Enfer,Chablais
-382,418.0,http://fr.dbpedia.org/resource/Grand_Ferrand,Grand Ferrand,5.815,44.7219,2758.0,Dévoluy,sommet,4,Grand Ferrand,Dévoluy
-383,419.0,http://fr.dbpedia.org/resource/Pic_de_Bure,Pic de Bure,5.935,44.6269,2709.0,Dévoluy,sommet,2,Pic de Bure,Dévoluy
-384,420.0,http://fr.dbpedia.org/resource/Salève,Salève,6.14028,46.0942,1379.0,Préalpes,sommet,4,Salève,Préalpes
-385,421.0,http://fr.dbpedia.org/resource/Caïres_de_Cougourde,Caïres de Cougourde,7.34583,44.1364,2921.0,Mercantour,sommet,4,Caïres de Cougourde,Mercantour
-386,422.0,http://fr.dbpedia.org/resource/Cime_du_Diable,Cime du Diable,7.42333,44.0492,2685.0,Mercantour,sommet,4,Cime du Diable,Mercantour
-387,423.0,http://fr.dbpedia.org/resource/Cime_du_Mercantour,Cime du Mercantour,7.29556,44.1439,2772.0,Mercantour,sommet,2,Cime du Mercantour,Mercantour
-388,424.0,http://fr.dbpedia.org/resource/Grand_Veymont,Grand Veymont,5.52694,44.87,2341.0,Vercors,sommet,1,Grand Veymont,Vercors
-389,425.0,http://fr.dbpedia.org/resource/Grande_Tête_de_l'Obiou,Grande Tête de l'Obiou,5.83944,44.7753,2789.0,Dévoluy,sommet,0,Grande Tête de l'Obiou,Dévoluy
-390,426.0,http://fr.dbpedia.org/resource/Lances_de_Malissard,Lances de Malissard,5.87333,45.3467,2045.0,Chartreuse,sommet,4,Lances de Malissard,Chartreuse
-391,427.0,http://fr.dbpedia.org/resource/Le_Râteau,Le Râteau,6.28056,45.0011,3809.0,Écrins,sommet,4,Le Râteau,Écrins
-392,428.0,http://fr.dbpedia.org/resource/Mont_Bégo,Mont Bégo,7.45083,44.0731,2872.0,Mercantour,sommet,0,Mont Bégo,Mercantour
-393,429.0,http://fr.dbpedia.org/resource/Mont_Mounier,Mont Mounier,6.97167,44.1542,2817.0,Mercantour,sommet,4,Mont Mounier,Mercantour
-394,430.0,http://fr.dbpedia.org/resource/Mont_Pelat,Mont Pelat,6.70583,44.2647,3050.0,Pelat,sommet,1,Mont Pelat,Pelat
-395,431.0,http://fr.dbpedia.org/resource/Mont_d'Ambin,Mont d'Ambin,6.88417,45.1569,3378.0,Mont-Cenis,sommet,4,Mont d'Ambin,Mont-Cenis
-396,432.0,http://fr.dbpedia.org/resource/Aiguille_Rouge,Aiguille Rouge,6.84861,45.5519,3227.0,Vanoise,sommet,4,Aiguille Rouge,Vanoise
-397,433.0,http://fr.dbpedia.org/resource/Aiguille_de_Chambeyron,Aiguille de Chambeyron,6.85611,44.5472,3412.0,Chambeyron,sommet,4,Aiguille de Chambeyron,Chambeyron
-398,434.0,http://fr.dbpedia.org/resource/Bellecôte,Bellecôte,6.78222,45.4928,3417.0,Vanoise,sommet,4,Bellecôte,Vanoise
-399,435.0,http://fr.dbpedia.org/resource/Brec_de_Chambeyron,Brec de Chambeyron,6.85278,44.5269,3389.0,Chambeyron,sommet,4,Brec de Chambeyron,Chambeyron
-400,436.0,http://fr.dbpedia.org/resource/Dôme_de_la_Sache,Dôme de la Sache,6.87056,45.5111,3601.0,Vanoise,sommet,4,Dôme de la Sache,Vanoise
-401,437.0,http://fr.dbpedia.org/resource/Dôme_des_Platières,Dôme des Platières,6.86389,45.5075,3473.0,Vanoise,sommet,4,Dôme des Platières,Vanoise
-402,438.0,http://fr.dbpedia.org/resource/Le_Fifre,Le Fifre,6.35667,44.9167,3699.0,Écrins,sommet,4,Le Fifre,Écrins
-403,439.0,http://fr.dbpedia.org/resource/Miélandre,Miélandre,5.19639,44.4847,1451.0,Diois,sommet,4,Miélandre,Diois
-404,440.0,http://fr.dbpedia.org/resource/Mont_Thabor_(France),Mont Thabor,6.56389,45.1142,3178.0,Cerces,sommet,0,Mont Thabor,Cerces
-405,441.0,http://fr.dbpedia.org/resource/Pierra_Menta,Pierra Menta,6.65083,45.6381,2714.0,Beaufortain,sommet,2,Pierra Menta,Beaufortain
-406,442.0,http://fr.dbpedia.org/resource/Rochers_de_la_Balme,Rochers de la Balme,5.5375,44.9897,2063.0,Vercors,sommet,4,Rochers de la Balme,Vercors
-407,443.0,http://fr.dbpedia.org/resource/Éperrimont,Éperrimont,5.61778,45.0197,1441.0,Vercors,sommet,4,Éperrimont,Vercors
-408,444.0,http://fr.dbpedia.org/resource/Grand_Coyer,Grand Coyer,6.68972,44.1003,2693.0,Pelat,sommet,4,Grand Coyer,Pelat
-409,445.0,http://fr.dbpedia.org/resource/Haute-Pointe,Haute-Pointe,6.54972,46.1753,1958.0,Chablais,sommet,4,Haute-Pointe,Chablais
-410,446.0,http://fr.dbpedia.org/resource/Montagne_de_Chabre,Montagne de Chabre,5.64278,44.2658,1393.0,Baronnies,sommet,2,Montagne de Chabre,Baronnies
-411,447.0,http://fr.dbpedia.org/resource/Roche_Veyrand,Roche Veyrand,5.84444,45.4289,1429.0,Chartreuse,sommet,4,Roche Veyrand,Chartreuse
-412,448.0,http://fr.dbpedia.org/resource/Cime_Guilié,Cime Guilié,7.31056,44.1475,2999.0,Mercantour,sommet,4,Cime Guilié,Mercantour
-413,449.0,http://fr.dbpedia.org/resource/Mont_Chenaillet,Mont Chenaillet,6.74028,44.9022,2650.0,Queyras,sommet,4,Mont Chenaillet,Queyras
-414,450.0,http://fr.dbpedia.org/resource/Montagne_des_Mémises,Montagne des Mémises,6.71306,46.3789,1674.0,Chablais,sommet,4,Montagne des Mémises,Chablais
-415,451.0,http://fr.dbpedia.org/resource/Pointe_de_Charbonnel,Pointe de Charbonnel,7.05556,45.2808,3752.0,Alpes grées,sommet,4,Pointe de Charbonnel,Alpes grées
-416,452.0,http://fr.dbpedia.org/resource/Aiguille_du_Chardonnet,Aiguille du Chardonnet,7.00139,45.9689,3824.0,Mont-Blanc,sommet,4,Aiguille du Chardonnet,Mont-Blanc
-417,453.0,http://fr.dbpedia.org/resource/Mont_Forchat,Mont Forchat,6.48833,46.2736,1545.0,Chablais,sommet,4,Mont Forchat,Chablais
-418,454.0,http://fr.dbpedia.org/resource/Mont_Jalla,Mont Jalla,5.72472,45.2047,635.0,Chartreuse,sommet,4,Mont Jalla,Chartreuse
-419,455.0,http://fr.dbpedia.org/resource/Mont_Serein,Mont Serein,5.26083,44.1853,1437.0,Baronnies,sommet,4,Mont Serein,Baronnies
-420,456.0,http://fr.dbpedia.org/resource/Aiguille_de_Roc,Aiguille de Roc,6.91889,45.9014,3409.0,Aiguilles de Chamonix,sommet,4,Aiguille de Roc,Aiguilles de Chamonix
-421,457.0,http://fr.dbpedia.org/resource/Aiguille_de_la_République,Aiguille de la République,6.92139,45.9056,3305.0,Aiguilles de Chamonix,sommet,4,Aiguille de la République,Aiguilles de Chamonix
-422,458.0,http://fr.dbpedia.org/resource/Aiguille_des_Pélerins,Aiguille des Pélerins,6.90167,45.895,3318.0,Aiguilles de Chamonix,sommet,4,Aiguille des Pélerins,Aiguilles de Chamonix
-423,459.0,http://fr.dbpedia.org/resource/Dent_du_Requin,Dent du Requin,6.9175,45.8878,3422.0,Aiguilles de Chamonix,sommet,4,Dent du Requin,Aiguilles de Chamonix
-424,460.0,http://fr.dbpedia.org/resource/Pointe_Richardson,Pointe Richardson,6.32028,44.8569,3312.0,Écrins,sommet,4,Pointe Richardson,Écrins
-425,461.0,http://fr.dbpedia.org/resource/Aiguille_de_Criou,Aiguille de Criou,6.76361,46.0953,2207.0,Giffre,sommet,4,Aiguille de Criou,Giffre
-426,462.0,http://fr.dbpedia.org/resource/Mont_Colombier,Mont Colombier,6.11944,45.6444,2043.0,Bauges,sommet,4,Mont Colombier,Bauges
-427,463.0,http://fr.dbpedia.org/resource/Pic_du_Frêne,Pic du Frêne,6.19806,45.3525,2807.0,Belledonne,sommet,4,Pic du Frêne,Belledonne
-428,464.0,http://fr.dbpedia.org/resource/Pointe_de_Sur_Cou,Pointe de Sur Cou,6.34639,46.02,1809.0,Bornes,sommet,4,Pointe de Sur Cou,Bornes
-429,465.0,http://fr.dbpedia.org/resource/Pointe_de_l'Aiglière,Pointe de l'Aiglière,6.41472,44.8103,3307.0,Écrins,sommet,4,Pointe de l'Aiglière,Écrins
-430,466.0,http://fr.dbpedia.org/resource/Pointe_de_l'Échelle,Pointe de l'Échelle,6.685,45.2692,3422.0,Vanoise,sommet,4,Pointe de l'Échelle,Vanoise
-431,467.0,http://fr.dbpedia.org/resource/Pointe_des_Jottis,Pointe des Jottis,6.52722,46.2136,1548.0,Chablais,sommet,4,Pointe des Jottis,Chablais
-432,468.0,http://fr.dbpedia.org/resource/Cime_de_Peïra-Cava,Cime de Peïra-Cava,7.37,43.9394,1581.0,Préalpes de Nice,sommet,4,Cime de Peïra-Cava,Préalpes de Nice
-433,469.0,http://fr.dbpedia.org/resource/Mont_Colombis,Mont Colombis,6.2175,44.495,1734.0,Alpes,sommet,4,Mont Colombis,Alpes
-434,470.0,http://fr.dbpedia.org/resource/Montagne_de_Maurel,Montagne de Maurel,6.52944,44.0117,1770.0,Trois-Évêchés,sommet,4,Montagne de Maurel,Trois-Évêchés
-435,471.0,http://fr.dbpedia.org/resource/Roc_de_Gleisin,Roc de Gleisin,5.84806,45.4422,1434.0,Chartreuse,sommet,4,Roc de Gleisin,Chartreuse
-436,472.0,http://fr.dbpedia.org/resource/Quatre_Têtes,Quatre Têtes,6.57278,45.9539,2364.0,Aravis,sommet,4,Quatre Têtes,Aravis
-437,473.0,http://fr.dbpedia.org/resource/Mont_Blanc,Mont Blanc,6.86472,45.8326,4810.02,Mont-Blanc,sommet,0,Mont Blanc,Mont-Blanc
-438,474.0,http://fr.dbpedia.org/resource/Aiguille_Verte,Aiguille Verte,6.97,45.9347,4122.0,Mont-Blanc,sommet,4,Aiguille Verte,Mont-Blanc
-439,475.0,http://fr.dbpedia.org/resource/Croix_de_Belledonne,Croix de Belledonne,5.98833,45.1686,2926.0,Belledonne,sommet,0,Croix de Belledonne,Belledonne
-440,476.0,http://fr.dbpedia.org/resource/Grandes_Jorasses,Grandes Jorasses,6.98806,45.8689,4208.0,Mont-Blanc,sommet,0,Grandes Jorasses,Mont-Blanc
-441,477.0,http://fr.dbpedia.org/resource/La_Meije,La Meije,6.30861,45.0047,3983.0,Écrins,sommet,0,La Meije,Écrins
-442,478.0,http://fr.dbpedia.org/resource/La_Tournette,La Tournette,6.28611,45.8272,2351.0,Bornes,sommet,4,La Tournette,Bornes
-443,479.0,http://fr.dbpedia.org/resource/Les_Drus,Les Drus,6.95639,45.9328,3754.0,Mont-Blanc,sommet,4,Les Drus,Mont-Blanc
-444,480.0,http://fr.dbpedia.org/resource/Mont_Agel,Mont Agel,7.42639,43.7753,1148.0,Préalpes de Nice,sommet,4,Mont Agel,Préalpes de Nice
-445,481.0,http://fr.dbpedia.org/resource/Mont_Aiguille,Mont Aiguille,5.55306,44.8419,2087.0,Vercors,sommet,0,Mont Aiguille,Vercors
-446,482.0,http://fr.dbpedia.org/resource/Mont_Granier,Mont Granier,5.92528,45.4647,1933.0,Chartreuse,sommet,0,Mont Granier,Chartreuse
-447,483.0,http://fr.dbpedia.org/resource/Mont_Pelvoux,Mont Pelvoux,6.39333,44.8981,3946.0,Écrins,sommet,0,Mont Pelvoux,Écrins
-448,484.0,http://fr.dbpedia.org/resource/Montagne_de_la_Mandallaz,Montagne de la Mandallaz,6.08,45.9758,929.0,Préalpes,sommet,4,Montagne de la Mandallaz,Préalpes
-449,485.0,http://fr.dbpedia.org/resource/Montagne_du_Cheval_Blanc,Montagne du Cheval Blanc,6.42389,44.1275,2323.0,Trois-Évêchés,sommet,4,Montagne du Cheval Blanc,Trois-Évêchés
-450,486.0,http://fr.dbpedia.org/resource/Tête_de_l'Estrop,Tête de l'Estrop,6.50472,44.2872,2961.0,Trois-Évêchés,sommet,0,Tête de l'Estrop,Trois-Évêchés
-451,487.0,http://fr.dbpedia.org/resource/Arcalod,Arcalod,6.22833,45.6819,2217.0,Bauges,sommet,4,Arcalod,Bauges
-452,488.0,http://fr.dbpedia.org/resource/Grand_Pinier,Grand Pinier,6.40139,44.7233,3117.0,Écrins,sommet,1,Grand Pinier,Écrins
-453,489.0,http://fr.dbpedia.org/resource/Mont_Chaberton,Mont Chaberton,6.75111,44.9644,3131.0,Cerces,sommet,4,Mont Chaberton,Cerces
-454,490.0,http://fr.dbpedia.org/resource/Montagne_du_Charbon,Montagne du Charbon,6.19028,45.7108,1932.0,Bauges,sommet,4,Montagne du Charbon,Bauges
-455,491.0,http://fr.dbpedia.org/resource/Pécloz,Pécloz,6.23111,45.6322,2197.0,Bauges,sommet,4,Pécloz,Bauges
-456,492.0,http://fr.dbpedia.org/resource/Montagne_de_Cordœil,Montagne de Cordœil,6.52944,44.0678,2114.0,Trois-Évêchés,sommet,4,Montagne de Cordœil,Trois-Évêchés
-457,493.0,http://fr.dbpedia.org/resource/Pointe_Bayeux,Pointe Bayeux,6.84389,45.8464,4258.0,Mont-Blanc,sommet,4,Pointe Bayeux,Mont-Blanc
-458,494.0,http://fr.dbpedia.org/resource/Rocher_de_la_Tournette,Rocher de la Tournette,6.85944,45.8328,4677.0,Mont-Blanc,sommet,4,Rocher de la Tournette,Mont-Blanc
-459,495.0,http://fr.dbpedia.org/resource/Signal_de_Saint-Pierre,Signal de Saint-Pierre,5.48528,43.9794,1256.0,Monts de Vaucluse,sommet,2,Signal de Saint-Pierre,Monts de Vaucluse
-460,496.0,http://fr.dbpedia.org/resource/Cime_de_Caron,Cime de Caron,6.56167,45.2631,3195.0,Vanoise,sommet,4,Cime de Caron,Vanoise
-461,497.0,http://fr.dbpedia.org/resource/Cime_de_Sistron,Cime de Sistron,7.1242,44.173,2603.0,Mercantour,sommet,4,Cime de Sistron,Mercantour
-462,498.0,http://fr.dbpedia.org/resource/Dôme_de_Chasseforêt,Dôme de Chasseforêt,6.76056,45.3306,3586.0,Vanoise,sommet,4,Dôme de Chasseforêt,Vanoise
-463,499.0,http://fr.dbpedia.org/resource/Mont_Bréquin,Mont Bréquin,6.53361,45.2517,3130.0,Vanoise,sommet,4,Mont Bréquin,Vanoise
-464,500.0,http://fr.dbpedia.org/resource/Mont_du_Borgne,Mont du Borgne,6.61333,45.3039,3153.0,Vanoise,sommet,4,Mont du Borgne,Vanoise
-465,501.0,http://fr.dbpedia.org/resource/Pic_Queyrel,Pic Queyrel,6.14528,44.7069,2435.0,Écrins,sommet,4,Pic Queyrel,Écrins
-466,502.0,http://fr.dbpedia.org/resource/Pic_du_Tourond,Pic du Tourond,6.18944,44.7161,2743.0,Écrins,sommet,4,Pic du Tourond,Écrins
-467,503.0,http://fr.dbpedia.org/resource/Pointe_du_Lingustier,Pointe du Lingustier,6.1613,44.7073,2359.0,Écrins,sommet,4,Pointe du Lingustier,Écrins
-468,504.0,http://fr.dbpedia.org/resource/Puy_de_Manse,Puy de Manse,6.15472,44.6147,1637.0,Écrins,sommet,4,Puy de Manse,Écrins
-469,505.0,http://fr.dbpedia.org/resource/Bric_Froid,Bric Froid,6.93139,44.8636,3302.0,Alpes cottiennes,sommet,4,Bric Froid,Alpes cottiennes
-470,506.0,http://fr.dbpedia.org/resource/Mont_Margériaz,Mont Margériaz,6.03444,45.6358,1845.0,Bauges,sommet,4,Mont Margériaz,Bauges
-471,507.0,http://fr.dbpedia.org/resource/Montagne_de_Bange,Montagne de Bange,6.03694,45.7297,1434.0,Bauges,sommet,4,Montagne de Bange,Bauges
-472,508.0,http://fr.dbpedia.org/resource/Montagne_de_Saint-Genis,Montagne de Saint-Genis,5.8375,44.3919,1432.0,Bochaine,sommet,1,Montagne de Saint-Genis,Bochaine
-473,509.0,http://fr.dbpedia.org/resource/Sommet_de_la_Saulire,Sommet de la Saulire,6.61056,45.3833,2738.0,Vanoise,sommet,4,Sommet de la Saulire,Vanoise
-474,510.0,http://fr.dbpedia.org/resource/Sommet_des_Anges,Sommet des Anges,6.71389,44.8939,2459.0,Queyras,sommet,4,Sommet des Anges,Queyras
-475,511.0,http://fr.dbpedia.org/resource/Tête_Grosse,Tête Grosse,6.27361,44.3314,2032.0,Préalpes de Digne,sommet,4,Tête Grosse,Préalpes de Digne
-476,512.0,http://fr.dbpedia.org/resource/Grand_Glaiza,Grand Glaiza,6.88194,44.8494,3293.0,Queyras,sommet,4,Grand Glaiza,Queyras
-477,513.0,http://fr.dbpedia.org/resource/Mont_Aiguillette,Mont Aiguillette,7.02444,44.6911,3287.0,Escreins,sommet,4,Mont Aiguillette,Escreins
-478,514.0,http://fr.dbpedia.org/resource/Pic_de_la_Belle_Étoile,Pic de la Belle Étoile,6.05417,45.2367,2718.0,Belledonne,sommet,4,Pic de la Belle Étoile,Belledonne
-479,515.0,http://fr.dbpedia.org/resource/Rachais,Rachais,5.74361,45.2417,1050.0,Chartreuse,sommet,4,Rachais,Chartreuse
-480,517.0,http://fr.dbpedia.org/resource/Aiguille_de_Chalais,Aiguille de Chalais,5.66056,45.2939,1089.0,Chartreuse,sommet,4,Aiguille de Chalais,Chartreuse
-481,518.0,http://fr.dbpedia.org/resource/Aiguille_de_Scolette,Aiguille de Scolette,6.76806,45.1597,3506.0,Mont-Cenis,sommet,4,Aiguille de Scolette,Mont-Cenis
-482,519.0,http://fr.dbpedia.org/resource/Blayeul,Blayeul,6.31167,44.2469,2189.0,Trois-Évêchés,sommet,4,Blayeul,Trois-Évêchés
-483,520.0,http://fr.dbpedia.org/resource/Crêt_Luisard,Crêt Luisard,6.05444,45.3181,1803.0,Belledonne,sommet,4,Crêt Luisard,Belledonne
-484,521.0,http://fr.dbpedia.org/resource/Crêt_du_Poulet,Crêt du Poulet,6.06,45.33,1726.0,Belledonne,sommet,4,Crêt du Poulet,Belledonne
-485,522.0,http://fr.dbpedia.org/resource/Dent_de_l'Ours,Dent de l'Ours,5.82083,45.3886,1820.0,Chartreuse,sommet,4,Dent de l'Ours,Chartreuse
-486,523.0,http://fr.dbpedia.org/resource/Grand_Rocher,Grand Rocher,6.05,45.3036,1926.0,Belledonne,sommet,4,Grand Rocher,Belledonne
-487,524.0,http://fr.dbpedia.org/resource/Mont_Joigny,Mont Joigny,5.89778,45.4917,1556.0,Chartreuse,sommet,4,Mont Joigny,Chartreuse
-488,525.0,http://fr.dbpedia.org/resource/Mont_Outheran,Mont Outheran,5.845,45.4658,1676.0,Chartreuse,sommet,4,Mont Outheran,Chartreuse
-489,526.0,http://fr.dbpedia.org/resource/Pointe_Marguareis,Pointe Marguareis,7.68472,44.1739,2651.0,Alpes ligures,sommet,4,Pointe Marguareis,Alpes ligures
-490,527.0,http://fr.dbpedia.org/resource/Dent_de_Moirans,Dent de Moirans,5.59556,45.2875,988.0,Vercors,sommet,2,Dent de Moirans,Vercors
-491,528.0,http://fr.dbpedia.org/resource/Dôme_de_Monêtier,Dôme de Monêtier,6.4525,44.9308,3404.0,Écrins,sommet,4,Dôme de Monêtier,Écrins
-492,529.0,http://fr.dbpedia.org/resource/La_Cucumelle,La Cucumelle,6.50889,44.9381,2698.0,Écrins,sommet,4,La Cucumelle,Écrins
-493,530.0,http://fr.dbpedia.org/resource/La_Tour_Ronde,La Tour Ronde,6.9075,45.8439,3792.0,Mont-Blanc,sommet,4,La Tour Ronde,Mont-Blanc
-494,531.0,http://fr.dbpedia.org/resource/Les_Courtes,Les Courtes,7.00347,45.9275,3856.0,Mont-Blanc,sommet,4,Les Courtes,Mont-Blanc
-495,532.0,http://fr.dbpedia.org/resource/Massif_d'Uchaux,Massif d'Uchaux,4.81389,44.2311,281.0,Baronnies,sommet,4,Massif d'Uchaux,Baronnies
-496,533.0,http://fr.dbpedia.org/resource/Montagne_des_Gures,Montagne des Gures,6.7475,45.9308,940.0,Mont-Blanc,sommet,4,Montagne des Gures,Mont-Blanc
-497,534.0,http://fr.dbpedia.org/resource/Pointe_de_la_Galoppaz,Pointe de la Galoppaz,6.06667,45.5658,1681.0,Bauges,sommet,4,Pointe de la Galoppaz,Bauges
-498,535.0,http://fr.dbpedia.org/resource/Serre_Chevalier_(montagne),Serre Chevalier (montagne),6.55,44.9108,2491.0,Écrins,sommet,4,Serre Chevalier,Écrins
-499,536.0,http://fr.dbpedia.org/resource/Tête_de_Siguret,Tête de Siguret,6.78806,44.4414,3032.0,Mercantour,sommet,4,Tête de Siguret,Mercantour
-500,537.0,http://fr.dbpedia.org/resource/Bec_de_Neurre,Bec de Neurre,5.47333,45.1636,1474.0,Vercors,sommet,2,Bec de Neurre,Vercors
-501,538.0,http://fr.dbpedia.org/resource/Bec_de_l'Orient,Bec de l'Orient,5.54722,45.2347,1568.0,Vercors,sommet,2,Bec de l'Orient,Vercors
-502,539.0,http://fr.dbpedia.org/resource/Bec_de_l'Échaillon,Bec de l'Échaillon,5.6025,45.2983,622.0,Vercors,sommet,4,Bec de l'Échaillon,Vercors
-503,540.0,http://fr.dbpedia.org/resource/Dôme_de_Bellefont,Dôme de Bellefont,5.88111,45.3419,1975.0,Chartreuse,sommet,4,Dôme de Bellefont,Chartreuse
-504,541.0,http://fr.dbpedia.org/resource/La_Buffe,La Buffe,5.58417,45.2439,1623.0,Vercors,sommet,4,La Buffe,Vercors
-505,542.0,http://fr.dbpedia.org/resource/La_Sure,La Sure,5.59778,45.2353,1643.0,Vercors,sommet,4,La Sure,Vercors
-506,543.0,http://fr.dbpedia.org/resource/Le_Marteau,Le Marteau,6.76278,45.9659,2289.0,Giffre,sommet,4,Le Marteau,Giffre
-507,544.0,http://fr.dbpedia.org/resource/Signal_de_Nave,Signal de Nave,5.53694,45.2236,1609.0,Vercors,sommet,4,Signal de Nave,Vercors
-508,545.0,http://fr.dbpedia.org/resource/Cime_du_Gélas,Cime du Gélas,7.38389,44.1228,3143.0,Mercantour,sommet,4,Cime du Gélas,Mercantour
-509,546.0,http://fr.dbpedia.org/resource/Dent_d'Oche,Dent d'Oche,6.73111,46.3531,2221.0,Chablais,sommet,4,Dent d'Oche,Chablais
-510,547.0,http://fr.dbpedia.org/resource/Mont_Charvin_(Aravis),Mont Charvin (Aravis),6.42028,45.8025,2409.0,Aravis,sommet,4,Mont Charvin,Aravis
-511,548.0,http://fr.dbpedia.org/resource/Parmelan,Parmelan,6.23806,45.9483,1832.0,Bornes,sommet,4,Parmelan,Bornes
-512,549.0,http://fr.dbpedia.org/resource/Mont_Prorel,Mont Prorel,6.58111,44.9053,2566.0,Écrins,sommet,4,Mont Prorel,Écrins
-513,550.0,http://fr.dbpedia.org/resource/Pics_de_Combeynot,Pics de Combeynot,6.41083,45.0125,3155.0,Écrins,sommet,4,Pics de Combeynot,Écrins
-514,551.0,http://fr.dbpedia.org/resource/Aiguille_Dibona,Aiguille Dibona,6.24278,44.9625,3131.0,Écrins,sommet,4,Aiguille Dibona,Écrins
-515,552.0,http://fr.dbpedia.org/resource/Aiguille_du_Plat_de_la_Selle,Aiguille du Plat de la Selle,6.22222,44.9636,3596.0,Écrins,sommet,4,Aiguille du Plat de la Selle,Écrins
-516,553.0,http://fr.dbpedia.org/resource/Charmant_Som,Charmant Som,5.76417,45.3253,1867.0,Chartreuse,sommet,2,Charmant Som,Chartreuse
-517,554.0,http://fr.dbpedia.org/resource/Cime_de_l'Encoula,Cime de l'Encoula,6.28333,44.905,3536.0,Écrins,sommet,4,Cime de l'Encoula,Écrins
-518,555.0,http://fr.dbpedia.org/resource/Dôme_de_Neige_des_Écrins,Dôme des Écrins,6.35389,44.9244,4015.0,Écrins,sommet,0,Dôme de Neige des Écrins,Écrins
-519,556.0,http://fr.dbpedia.org/resource/Grand_Som,Grand Som,5.81194,45.3706,2026.0,Chartreuse,sommet,0,Grand Som,Chartreuse
-520,557.0,http://fr.dbpedia.org/resource/Grande_Casse,Grande Casse,6.8275,45.4053,3855.0,Vanoise,sommet,0,Grande Casse,Vanoise
-521,558.0,http://fr.dbpedia.org/resource/Grande_Moucherolle,Grande Moucherolle,5.56417,45.0053,2284.0,Vercors,sommet,1,Grande Moucherolle,Vercors
-522,559.0,http://fr.dbpedia.org/resource/Grande_Ruine,Grande Ruine,6.32889,44.9675,3765.0,Écrins,sommet,4,Grande Ruine,Écrins
-523,560.0,http://fr.dbpedia.org/resource/Grande_Sure,Grande Sure,5.70333,45.3353,1920.0,Chartreuse,sommet,4,Grande Sure,Chartreuse
-524,561.0,http://fr.dbpedia.org/resource/Grande_aiguille_de_la_Bérarde,Grande aiguille de la Bérarde,6.2775,44.9161,3421.0,Écrins,sommet,4,Grande aiguille de la Bérarde,Écrins
-525,562.0,http://fr.dbpedia.org/resource/L'Ailefroide,L'Ailefroide,6.35667,44.885,3954.0,Écrins,sommet,4,L'Ailefroide,Écrins
-526,563.0,http://fr.dbpedia.org/resource/L'Olan,L'Olan,6.19667,44.8589,3564.0,Écrins,sommet,4,L'Olan,Écrins
-527,564.0,http://fr.dbpedia.org/resource/Le_Plaret,Le Plaret,6.25889,44.9681,3563.0,Écrins,sommet,4,Le Plaret,Écrins
-528,565.0,http://fr.dbpedia.org/resource/Le_Sirac,Le Sirac,6.30667,44.7889,3441.0,Écrins,sommet,2,Le Sirac,Écrins
-529,566.0,http://fr.dbpedia.org/resource/Les_Bans,Les Bans,6.33611,44.8483,3669.0,Écrins,sommet,4,Les Bans,Écrins
-530,567.0,http://fr.dbpedia.org/resource/Les_Rouies,Les Rouies,6.25806,44.8636,3589.0,Écrins,sommet,4,Les Rouies,Écrins
-531,568.0,http://fr.dbpedia.org/resource/Mont_Blanc_du_Tacul,Mont Blanc du Tacul,6.88778,45.8567,4248.0,Mont-Blanc,sommet,4,Mont Blanc du Tacul,Mont-Blanc
-532,569.0,http://fr.dbpedia.org/resource/Mont_Charvin_(Maurienne),Mont Charvin (Maurienne),6.28472,45.2172,2207.0,Arves,sommet,4,Mont Charvin,Arves
-533,570.0,http://fr.dbpedia.org/resource/Mont_Maudit,Mont Maudit,6.87583,45.8478,4465.0,Mont-Blanc,sommet,4,Mont Maudit,Mont-Blanc
-534,571.0,http://fr.dbpedia.org/resource/Montagne_des_Agneaux,Montagne des Agneaux,6.42972,44.9503,3664.0,Écrins,sommet,4,Montagne des Agneaux,Écrins
-535,572.0,http://fr.dbpedia.org/resource/Pic_Coolidge,Pic Coolidge,6.35694,44.9106,3774.0,Écrins,sommet,1,Pic Coolidge,Écrins
-536,573.0,http://fr.dbpedia.org/resource/Pic_Gaspard,Pic Gaspard,6.33083,44.9983,3881.0,Écrins,sommet,4,Pic Gaspard,Écrins
-537,574.0,http://fr.dbpedia.org/resource/Pic_de_Neige_Cordier,Pic de Neige Cordier,6.38889,44.9561,3614.0,Écrins,sommet,4,Pic de Neige Cordier,Écrins
-538,575.0,http://fr.dbpedia.org/resource/Pic_de_la_Grave,Pic de la Grave,6.24944,44.9964,3667.0,Écrins,sommet,2,Pic de la Grave,Écrins
-539,576.0,http://fr.dbpedia.org/resource/Pinéa,Pinéa,5.73861,45.2883,1771.0,Chartreuse,sommet,4,Pinéa,Chartreuse
-540,577.0,http://fr.dbpedia.org/resource/Pointe_Guyard,Pointe Guyard,6.39083,44.8597,3461.0,Écrins,sommet,4,Pointe Guyard,Écrins
-541,578.0,http://fr.dbpedia.org/resource/Pointe_des_Arcas,Pointe des Arcas,6.4475,44.9264,3479.0,Écrins,sommet,4,Pointe des Arcas,Écrins
-542,579.0,http://fr.dbpedia.org/resource/Roche_Faurio,Roche Faurio,6.35722,44.9417,3730.0,Écrins,sommet,4,Roche Faurio,Écrins
-543,580.0,http://fr.dbpedia.org/resource/Roche_de_la_Muzelle,Roche de la Muzelle,6.10528,44.9311,3465.0,Écrins,sommet,2,Roche de la Muzelle,Écrins
-544,581.0,http://fr.dbpedia.org/resource/Tête_de_l'Étret,Tête de l'Étret,6.24472,44.8894,3559.0,Écrins,sommet,1,Tête de l'Étret,Écrins
-545,582.0,http://fr.dbpedia.org/resource/Tête_de_la_Gandolière,Tête de la Gandolière,6.27028,44.9739,3542.0,Écrins,sommet,4,Tête de la Gandolière,Écrins
-546,583.0,http://fr.dbpedia.org/resource/Tête_des_Fétoules,Tête des Fétoules,6.23667,44.8997,3459.0,Écrins,sommet,4,Tête des Fétoules,Écrins
-547,584.0,http://fr.dbpedia.org/resource/Arêtes_du_Gerbier,Arêtes du Gerbier,5.58917,45.0253,2109.0,Vercors,sommet,4,Arêtes du Gerbier,Vercors
-548,585.0,http://fr.dbpedia.org/resource/Connex_(sommet),Connex (sommet),5.74167,45.0461,1360.0,Taillefer,sommet,4,Connex,Taillefer
-549,586.0,http://fr.dbpedia.org/resource/Dent_Parrachée,Dent Parrachée,6.75611,45.2919,3697.0,Vanoise,sommet,0,Dent Parrachée,Vanoise
-550,587.0,http://fr.dbpedia.org/resource/Dent_de_Cons,Dent de Cons,6.35111,45.7297,2062.0,Bauges,sommet,4,Dent de Cons,Bauges
-551,588.0,http://fr.dbpedia.org/resource/Dent_du_Géant,Dent du Géant,6.95167,45.8619,4013.0,Mont-Blanc,sommet,4,Dent du Géant,Mont-Blanc
-552,589.0,http://fr.dbpedia.org/resource/Goléon,Goléon,6.32639,45.1036,3427.0,Arves,sommet,4,Goléon,Arves
-553,590.0,http://fr.dbpedia.org/resource/Grand_Galbert,Grand Galbert,5.95944,45.0906,2561.0,Taillefer,sommet,4,Grand Galbert,Taillefer
-554,591.0,http://fr.dbpedia.org/resource/Grand_Galibier,Grand Galibier,6.43389,45.0642,3228.0,Cerces,sommet,4,Grand Galibier,Cerces
-555,592.0,http://fr.dbpedia.org/resource/Grand_Serre,Grand Serre,5.82639,45.0056,2141.0,Taillefer,sommet,4,Grand Serre,Taillefer
-556,593.0,http://fr.dbpedia.org/resource/Grand_pic_de_Belledonne,Grand pic de Belledonne,5.99167,45.1711,2977.0,Belledonne,sommet,4,Grand pic de Belledonne,Belledonne
-557,594.0,http://fr.dbpedia.org/resource/Le_Brévent,Le Brévent,6.83778,45.9342,2525.0,Aiguilles Rouges,sommet,4,Le Brévent,Aiguilles Rouges
-558,595.0,http://fr.dbpedia.org/resource/Mont_Buet,Mont Buet,6.8525,46.025,3096.0,Giffre,sommet,4,Mont Buet,Giffre
-559,596.0,http://fr.dbpedia.org/resource/Mont_Mirantin,Mont Mirantin,6.49889,45.6844,2460.0,Beaufortain,sommet,4,Mont Mirantin,Beaufortain
-560,597.0,http://fr.dbpedia.org/resource/Moucherotte,Moucherotte,5.63917,45.1478,1901.0,Vercors,sommet,1,Moucherotte,Vercors
-561,598.0,http://fr.dbpedia.org/resource/Négresse_(sommet),Négresse (sommet),6.34222,45.7042,1720.0,Bauges,sommet,4,Négresse,Bauges
-562,599.0,http://fr.dbpedia.org/resource/Peyrouse_(sommet),Peyrouse (sommet),5.72472,44.9922,1710.0,Taillefer,sommet,4,Peyrouse,Taillefer
-563,600.0,http://fr.dbpedia.org/resource/Pié_Ferré,Pié Ferré,5.47028,44.7372,2041.0,Vercors,sommet,4,Pié Ferré,Vercors
-564,601.0,http://fr.dbpedia.org/resource/Pointe_de_Nantaux,Pointe de Nantaux,6.70806,46.2258,2170.0,Chablais,sommet,4,Pointe de Nantaux,Chablais
-565,602.0,http://fr.dbpedia.org/resource/Roc_Cornafion,Roc Cornafion,5.60083,45.0622,2049.0,Vercors,sommet,4,Roc Cornafion,Vercors
-566,603.0,http://fr.dbpedia.org/resource/Roche_Pourrie,Roche Pourrie,6.46028,45.6842,2037.0,Beaufortain,sommet,4,Roche Pourrie,Beaufortain
-567,604.0,http://fr.dbpedia.org/resource/Rocher_Blanc,Rocher Blanc,6.1075,45.2417,2927.0,Belledonne,sommet,4,Rocher Blanc,Belledonne
-568,605.0,http://fr.dbpedia.org/resource/Sommet_de_Malaval,Sommet de Malaval,5.51917,44.9258,2097.0,Vercors,sommet,4,Sommet de Malaval,Vercors
-569,606.0,http://fr.dbpedia.org/resource/Tabor_(sommet),Tabor (sommet),5.85556,44.9772,2389.0,Taillefer,sommet,4,Tabor,Taillefer
-570,607.0,http://fr.dbpedia.org/resource/Taillefer_(sommet),Taillefer (sommet),5.92419,45.0394,2857.0,Taillefer,sommet,0,Taillefer,Taillefer
-571,608.0,http://fr.dbpedia.org/resource/Tête_de_Chien,Tête de Chien,7.40222,43.7308,550.0,Préalpes de Nice,sommet,4,Tête de Chien,Préalpes de Nice
-572,609.0,http://fr.dbpedia.org/resource/Cornebois,Cornebois,6.80889,46.2114,2200.0,Chablais,sommet,4,Cornebois,Chablais
-573,610.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-574,611.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-575,612.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-576,613.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-577,614.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-578,615.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-579,616.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-580,617.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-581,618.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1216,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-582,619.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-583,620.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-584,621.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-585,622.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-586,623.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-587,624.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-588,625.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-589,626.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-590,627.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1233,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-591,628.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-592,629.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-593,630.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-594,631.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-595,632.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-596,633.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-597,634.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-598,635.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-599,636.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1363,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-600,637.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-601,638.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-602,639.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-603,640.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-604,641.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-605,642.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-606,643.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-607,644.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-608,645.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1369,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-609,646.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-610,647.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-611,648.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-612,649.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-613,650.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-614,651.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-615,652.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-616,653.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-617,654.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1372,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-618,655.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-619,656.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-620,657.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-621,658.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-622,659.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-623,660.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-624,661.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-625,662.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-626,663.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1794,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-627,664.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-628,665.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-629,666.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-630,667.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-631,668.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-632,669.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-633,670.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-634,671.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-635,672.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1993,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-636,673.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-637,674.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-638,675.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-639,676.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-640,677.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-641,678.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-642,679.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-643,680.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-644,681.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.2057,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-645,682.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-646,683.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-647,684.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-648,685.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-649,686.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-650,687.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-651,688.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-652,689.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-653,690.0,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.2167,730.0,Monts de Vaucluse,sommet,4,Dentelles de Montmirail,Monts de Vaucluse
-654,691.0,http://fr.dbpedia.org/resource/Grand_Bérard,Grand Bérard,6.66,44.4494,3046.0,Parpaillon,sommet,4,Grand Bérard,Parpaillon
-655,692.0,http://fr.dbpedia.org/resource/Mont_Revard,Mont Revard,5.98972,45.6894,1562.0,Bauges,sommet,4,Mont Revard,Bauges
-656,693.0,http://fr.dbpedia.org/resource/Pic_de_Rochebrune,Pic de Rochebrune,6.78722,44.8225,3320.0,Queyras,sommet,4,Pic de Rochebrune,Queyras
-657,694.0,http://fr.dbpedia.org/resource/Pointe_de_la_Sana,Pointe de la Sana,6.9175,45.3853,3436.0,Vanoise,sommet,4,Pointe de la Sana,Vanoise
-658,695.0,http://fr.dbpedia.org/resource/Aiguille_de_Bionnassay,Aiguille de Bionnassay,6.81806,45.8358,4052.0,Mont-Blanc,sommet,1,Aiguille de Bionnassay,Mont-Blanc
-659,696.0,http://fr.dbpedia.org/resource/Aiguille_de_Borderan,Aiguille de Borderan,6.47778,45.8864,2492.0,Aravis,sommet,4,Aiguille de Borderan,Aravis
-660,697.0,http://fr.dbpedia.org/resource/Aiguille_de_Quaix,Aiguille de Quaix,5.72,45.2669,1143.0,Chartreuse,sommet,4,Aiguille de Quaix,Chartreuse
-661,698.0,http://fr.dbpedia.org/resource/Aiguille_du_Goûter,Aiguille du Goûter,6.83111,45.8506,3863.0,Mont-Blanc,sommet,4,Aiguille du Goûter,Mont-Blanc
-662,699.0,http://fr.dbpedia.org/resource/Chamechaude,Chamechaude,5.78806,45.2875,2082.0,Chartreuse,sommet,1,Chamechaude,Chartreuse
-663,700.0,http://fr.dbpedia.org/resource/Grand_Margès,Grand Margès,6.27861,43.7556,1576.0,Préalpes de Castellane,sommet,4,Grand Margès,Préalpes de Castellane
-664,701.0,http://fr.dbpedia.org/resource/Grande_Balmaz,Grande Balmaz,6.49639,45.8931,2616.0,Aravis,sommet,4,Grande Balmaz,Aravis
-665,702.0,http://fr.dbpedia.org/resource/Grands_Crêts,Grands Crêts,5.81361,45.2711,1489.0,Chartreuse,sommet,4,Grands Crêts,Chartreuse
-666,703.0,http://fr.dbpedia.org/resource/Mont_Boron,Mont Boron,7.30083,43.69,191.3,Préalpes de Nice,sommet,4,Mont Boron,Préalpes de Nice
-667,704.0,http://fr.dbpedia.org/resource/Mont_Charvet,Mont Charvet,6.53861,45.9422,2538.0,Aravis,sommet,4,Mont Charvet,Aravis
-668,705.0,http://fr.dbpedia.org/resource/Mont_Chiran,Mont Chiran,6.31667,43.8681,1905.0,Préalpes de Digne,sommet,4,Mont Chiran,Préalpes de Digne
-669,706.0,http://fr.dbpedia.org/resource/Mont_Fleuri_(sommet),Mont Fleuri (sommet),6.53361,45.9328,2511.0,Aravis,sommet,4,Mont Fleuri,Aravis
-670,707.0,http://fr.dbpedia.org/resource/Mont_Saint-Eynard,Mont Saint-Eynard,5.79917,45.2597,1379.0,Chartreuse,sommet,4,Mont Saint-Eynard,Chartreuse
-671,708.0,http://fr.dbpedia.org/resource/Montagne_du_Cheiron,Montagne du Cheiron,6.96944,43.8147,1778.0,Préalpes de Castellane,sommet,4,Montagne du Cheiron,Préalpes de Castellane
-672,709.0,http://fr.dbpedia.org/resource/Mourre_de_Chanier,Mourre de Chanier,6.35083,43.8417,1930.0,Préalpes de Digne,sommet,4,Mourre de Chanier,Préalpes de Digne
-673,710.0,http://fr.dbpedia.org/resource/Néron_(Isère),Néron (Isère),5.71,45.2344,1298.0,Chartreuse,sommet,4,Néron,Chartreuse
-674,711.0,http://fr.dbpedia.org/resource/Parrossaz,Parrossaz,6.485,45.8881,2556.0,Aravis,sommet,4,Parrossaz,Aravis
-675,712.0,http://fr.dbpedia.org/resource/Pic_de_Jallouvre,Pic de Jallouvre,6.45222,45.9958,2408.0,Bornes,sommet,4,Pic de Jallouvre,Bornes
-676,713.0,http://fr.dbpedia.org/resource/Pointe_Blanche_(montagne),Pointe Blanche (montagne),6.46,45.9989,2438.0,Bornes,sommet,4,Pointe Blanche,Bornes
-677,714.0,http://fr.dbpedia.org/resource/Pointe_Percée,Pointe Percée,6.55556,45.9558,2750.0,Aravis,sommet,0,Pointe Percée,Aravis
-678,715.0,http://fr.dbpedia.org/resource/Pointe_de_Bella_Cha,Pointe de Bella Cha,6.56361,45.9717,2511.0,Aravis,sommet,4,Pointe de Bella Cha,Aravis
-679,716.0,http://fr.dbpedia.org/resource/Roche_Perfia,Roche Perfia,6.51361,45.9144,2499.0,Aravis,sommet,4,Roche Perfia,Aravis
-680,717.0,http://fr.dbpedia.org/resource/Roualle,Roualle,6.50278,45.9008,2589.0,Aravis,sommet,4,Roualle,Aravis
-681,718.0,http://fr.dbpedia.org/resource/Tardevant,Tardevant,6.52583,45.9264,2501.0,Aravis,sommet,4,Tardevant,Aravis
-682,719.0,http://fr.dbpedia.org/resource/Tête_Pelouse,Tête Pelouse,6.50972,45.9092,2537.0,Aravis,sommet,4,Tête Pelouse,Aravis
-683,720.0,http://fr.dbpedia.org/resource/Tête_de_Paccaly,Tête de Paccaly,6.52,45.9189,2467.0,Aravis,sommet,4,Tête de Paccaly,Aravis
-684,721.0,http://fr.dbpedia.org/resource/Écoutoux,Écoutoux,5.75778,45.2531,1406.0,Chartreuse,sommet,4,Écoutoux,Chartreuse
-685,722.0,http://fr.dbpedia.org/resource/Dents_de_Lanfon,Dents de Lanfon,6.24167,45.8611,1824.0,Bornes,sommet,4,Dents de Lanfon,Bornes
-686,723.0,http://fr.dbpedia.org/resource/Mont_Coin,Mont Coin,6.62056,45.6319,2539.0,Beaufortain,sommet,4,Mont Coin,Beaufortain
-687,724.0,http://fr.dbpedia.org/resource/Petite_Aiguille_Verte,Petite Aiguille Verte,6.96333,45.9436,3512.0,Mont-Blanc,sommet,4,Petite Aiguille Verte,Mont-Blanc
-688,725.0,http://fr.dbpedia.org/resource/Aiguille_du_Peigne,Aiguille du Peigne,6.89944,45.8958,3192.0,Aiguilles de Chamonix,sommet,4,Aiguille du Peigne,Aiguilles de Chamonix
-689,726.0,http://fr.dbpedia.org/resource/Cime_de_Baissette,Cime de Baissette,7.31083,44.1364,2822.0,Mercantour,sommet,4,Cime de Baissette,Mercantour
-690,727.0,http://fr.dbpedia.org/resource/Fort_Carra,Fort Carra,6.8075,44.2456,2880.0,Mercantour,sommet,4,Fort Carra,Mercantour
-691,728.0,http://fr.dbpedia.org/resource/Grande_Lauzière,Grande Lauzière,5.95889,45.1569,2741.0,Belledonne,sommet,0,Grande Lauzière,Belledonne
-692,729.0,http://fr.dbpedia.org/resource/Petite_Autane,Petite Autane,6.24694,44.6408,2519.0,Écrins,sommet,4,Petite Autane,Écrins
-693,730.0,http://fr.dbpedia.org/resource/Pointe_de_Rougnoux,Pointe de Rougnoux,6.35944,44.7583,3179.0,Écrins,sommet,4,Pointe de Rougnoux,Écrins
-694,731.0,http://fr.dbpedia.org/resource/Tête_de_l'Enchastraye,Tête de l'Enchastraye,6.88778,44.3669,2954.0,Mercantour,sommet,4,Tête de l'Enchastraye,Mercantour
-695,732.0,http://fr.dbpedia.org/resource/Cime_Gardoria,Cime Gardoria,6.73611,45.1383,3137.0,Mont-Cenis,sommet,4,Cime Gardoria,Mont-Cenis
-696,733.0,http://fr.dbpedia.org/resource/Cime_du_Grand_Vallon,Cime du Grand Vallon,6.71167,45.1447,3129.0,Mont-Cenis,sommet,4,Cime du Grand Vallon,Mont-Cenis
-697,734.0,http://fr.dbpedia.org/resource/Croise_Baulet,Croise Baulet,6.55222,45.8983,2236.0,Aravis,sommet,4,Croise Baulet,Aravis
-698,735.0,http://fr.dbpedia.org/resource/Pointe_Sommeiller,Pointe Sommeiller,6.85222,45.1278,3332.0,Mont-Cenis,sommet,4,Pointe Sommeiller,Mont-Cenis
-699,736.0,http://fr.dbpedia.org/resource/Pointe_de_Paumont,Pointe de Paumont,6.72861,45.1392,3171.0,Mont-Cenis,sommet,4,Pointe de Paumont,Mont-Cenis
-700,737.0,http://fr.dbpedia.org/resource/Pointe_du_Fréjus,Tunnel de Fréjus,6.68028,45.1403,2934.0,Mont-Cenis,autre,0,Pointe du Fréjus,
-701,738.0,http://fr.dbpedia.org/resource/Tête_du_Danay,Tête du Danay,6.44861,45.9219,1731.0,Aravis,sommet,4,Tête du Danay,Aravis
-702,739.0,http://fr.dbpedia.org/resource/Aiguille_du_Fruit,Aiguille du Fruit,6.63111,45.3556,3048.0,Vanoise,sommet,4,Aiguille du Fruit,Vanoise
-703,740.0,http://fr.dbpedia.org/resource/Aiguille_du_Moine,Aiguille du Moine,6.96139,45.9167,3412.0,Mont-Blanc,sommet,4,Aiguille du Moine,Mont-Blanc
-704,741.0,http://fr.dbpedia.org/resource/Mont_Malinvern,Mont Malinvern,7.18889,44.1986,2938.0,Mercantour,sommet,4,Mont Malinvern,Mercantour
-705,742.0,http://fr.dbpedia.org/resource/Punta_dell'Alp,Punta dell'Alp,6.97111,44.6772,3033.0,Escreins,sommet,4,Punta dell'Alp,Escreins
-706,743.0,http://fr.dbpedia.org/resource/Rocher_Rond,Rocher Rond,5.82726,44.6966,2453.0,Dévoluy,sommet,4,Rocher Rond,Dévoluy
-707,744.0,http://fr.dbpedia.org/resource/Tête_de_l'Homme,Tête de l'Homme,6.775,44.4903,2504.0,Chambeyron,sommet,4,Tête de l'Homme,Chambeyron
-708,745.0,http://fr.dbpedia.org/resource/Albaron_(sommet),Albaron,7.10111,45.3339,3638.0,Alpes grées,sommet,4,Albaron,Alpes grées
-709,746.0,http://fr.dbpedia.org/resource/Bessanèse,Bessanèse,7.11667,45.3,3592.0,Alpes grées,sommet,4,Bessanèse,Alpes grées
-710,747.0,http://fr.dbpedia.org/resource/Aiguille_de_la_Grande_Sassière,Aiguille de la Grande Sassière,6.99972,45.5047,3747.0,Alpes grées,sommet,4,Aiguille de la Grande Sassière,Alpes grées
-711,748.0,http://fr.dbpedia.org/resource/Dôme_de_Barrot,Dôme de Barrot,6.91667,44.0367,2137.0,Mercantour,sommet,4,Dôme de Barrot,Mercantour
-712,749.0,http://fr.dbpedia.org/resource/Montagne_d'Angèle,Montagne d'Angèle,5.2575,44.4878,1606.0,Diois,sommet,4,Montagne d'Angèle,Diois
-713,750.0,http://fr.dbpedia.org/resource/Pointe_Côte_de_l'Âne,Pointe Côte de l'Âne,6.80444,44.2444,2916.0,Mercantour,sommet,4,Pointe Côte de l'Âne,Mercantour
-714,751.0,http://fr.dbpedia.org/resource/Pointe_de_la_Galise,Pointe de la Galise,7.10444,45.4669,3343.0,Alpes grées,sommet,4,Pointe de la Galise,Alpes grées
-715,752.0,http://fr.dbpedia.org/resource/Cheval_Noir,Cheval Noir,6.41361,45.4219,2832.0,Vanoise,sommet,2,Cheval Noir,Vanoise
-716,753.0,http://fr.dbpedia.org/resource/Les_Monges,Les Monges,6.19417,44.2628,2115.0,Préalpes de Digne,sommet,4,Les Monges,Préalpes de Digne
-717,754.0,http://fr.dbpedia.org/resource/Mont_Saint-Honorat,Mont Saint-Honorat,6.76444,44.0764,2520.0,Pelat,sommet,4,Mont Saint-Honorat,Pelat
-718,755.0,http://fr.dbpedia.org/resource/Mont_Tournairet,Mont Tournairet,7.23389,44.0161,2086.0,Mercantour,sommet,4,Mont Tournairet,Mercantour
-719,756.0,http://fr.dbpedia.org/resource/Pointe_du_Charbonnier,Pointe du Charbonnier,6.90111,45.3806,3311.0,Vanoise,sommet,4,Pointe du Charbonnier,Vanoise
-720,757.0,http://fr.dbpedia.org/resource/Rateau_d'Aussois,Rateau d'Aussois,6.69389,45.2464,3131.0,Vanoise,sommet,4,Rateau d'Aussois,Vanoise
-721,758.0,http://fr.dbpedia.org/resource/Grande_aiguille_Rousse,Grande aiguille Rousse,7.1096,45.4329,3482.0,Alpes grées,sommet,4,Grande aiguille Rousse,Alpes grées
-722,759.0,http://fr.dbpedia.org/resource/Ouille_d'Arbéron,Ouille d'Arbéron,7.12778,45.2717,3563.0,Alpes grées,sommet,4,Ouille d'Arbéron,Alpes grées
-723,760.0,http://fr.dbpedia.org/resource/Peygros,Peygros,6.68944,43.6611,778.0,Préalpes de Castellane,sommet,4,Peygros,Préalpes de Castellane
-724,761.0,http://fr.dbpedia.org/resource/Sommet_du_Pinet,Sommet du Pinet,5.90389,45.4325,1867.0,Chartreuse,sommet,4,Sommet du Pinet,Chartreuse
-725,762.0,http://fr.dbpedia.org/resource/Bauroux,Bauroux,6.71778,43.7811,1644.0,Préalpes de Castellane,sommet,4,Bauroux,Préalpes de Castellane
-726,763.0,http://fr.dbpedia.org/resource/Pain_de_Sucre_d'Envers_du_Plan,Pain de Sucre d'Envers du Plan,6.90917,45.89,3607.0,Aiguilles de Chamonix,sommet,4,Pain de Sucre d'Envers du Plan,Aiguilles de Chamonix
-727,764.0,http://fr.dbpedia.org/resource/Tour_Noir,Tour Noir,7.0375,45.9486,3837.0,Mont-Blanc,sommet,4,Tour Noir,Mont-Blanc
-728,765.0,http://fr.dbpedia.org/resource/Aiguille_d'Argentière,Aiguille d'Argentière,7.02028,45.9597,3902.0,Mont-Blanc,sommet,4,Aiguille d'Argentière,Mont-Blanc
-729,766.0,http://fr.dbpedia.org/resource/Aiguille_de_la_Vanoise,Aiguille de la Vanoise,6.77917,45.3947,2796.0,Vanoise,sommet,4,Aiguille de la Vanoise,Vanoise
-730,767.0,http://fr.dbpedia.org/resource/Château_d'Oche_(montagne),Château d'Oche,6.74306,46.35,2197.0,Chablais,sommet,4,Château d'Oche,Chablais
-731,768.0,http://fr.dbpedia.org/resource/Grand_Arc,Grand Arc,6.36472,45.5664,2484.0,Lauzière,sommet,4,Grand Arc,Lauzière
-732,769.0,http://fr.dbpedia.org/resource/Grand_pic_de_la_Lauzière,Grand pic de la Lauzière,6.36639,45.4592,2829.0,Lauzière,sommet,4,Grand pic de la Lauzière,Lauzière
-733,770.0,http://fr.dbpedia.org/resource/Grande_Motte,Grande Motte,6.87028,45.4111,3653.0,Vanoise,sommet,4,Grande Motte,Vanoise
-734,771.0,http://fr.dbpedia.org/resource/Hauts-Forts,Hauts-Forts,6.7775,46.1686,2466.0,Chablais,sommet,4,Hauts-Forts,Chablais
-735,772.0,http://fr.dbpedia.org/resource/Jocou,Jocou,5.6475,44.7244,2051.0,Diois,sommet,4,Jocou,Diois
-736,773.0,http://fr.dbpedia.org/resource/Mont_Férion,Mont Férion,7.2725,43.8686,1412.0,Préalpes de Nice,sommet,4,Mont Férion,Préalpes de Nice
-737,774.0,http://fr.dbpedia.org/resource/Mont_Turia,Mont Turia,6.86056,45.5325,3650.0,Vanoise,sommet,4,Mont Turia,Vanoise
-738,775.0,http://fr.dbpedia.org/resource/Mont_Ténibre,Mont Ténibre,6.97139,44.2839,3031.0,Mercantour,sommet,2,Mont Ténibre,Mercantour
-739,776.0,http://fr.dbpedia.org/resource/Mont_de_Grange,Mont de Grange,6.78056,46.2625,2432.0,Chablais,sommet,4,Mont de Grange,Chablais
-740,777.0,http://fr.dbpedia.org/resource/Montagne_de_la_Lance,Montagne de la Lance,5.10083,44.4575,1338.0,Diois,sommet,1,Montagne de la Lance,Diois
-741,778.0,http://fr.dbpedia.org/resource/Pic_Bayle,Pic Bayle,6.13583,45.1381,3465.0,Grandes Rousses,sommet,4,Pic Bayle,Grandes Rousses
-742,779.0,http://fr.dbpedia.org/resource/Pics_de_la_Font_Sancte,Pics de la Font Sancte,6.79972,44.6047,3385.0,Escreins,sommet,4,Pics de la Font Sancte,Escreins
-743,780.0,http://fr.dbpedia.org/resource/Pointe_de_Chavanette,Pointe de Chavanette,6.80694,46.1781,2219.0,Chablais,sommet,4,Pointe de Chavanette,Chablais
-744,781.0,http://fr.dbpedia.org/resource/Pointe_de_Chésery,Pointe de Chésery,6.80361,46.2033,2251.0,Chablais,sommet,4,Pointe de Chésery,Chablais
-745,782.0,http://fr.dbpedia.org/resource/Pointe_de_Fornet,Pointe de Fornet,6.79194,46.1633,2300.0,Chablais,sommet,4,Pointe de Fornet,Chablais
-746,783.0,http://fr.dbpedia.org/resource/Pointe_de_Ronce,Pointe de Ronce,6.97833,45.2647,3612.0,Mont-Cenis,sommet,4,Pointe de Ronce,Mont-Cenis
-747,784.0,http://fr.dbpedia.org/resource/Pointe_de_Vorlaz,Pointe de Vorlaz,6.79972,46.1817,2346.0,Chablais,sommet,4,Pointe de Vorlaz,Chablais
-748,785.0,http://fr.dbpedia.org/resource/Pointes_et_aiguille_de_l'Épéna,Pointes et aiguille de l'Épéna,6.81722,45.4142,3421.0,Vanoise,sommet,4,Pointes et aiguille de l'Épéna,Vanoise
-749,786.0,http://fr.dbpedia.org/resource/Tête_du_Géant,Tête du Géant,6.81639,46.22,2228.0,Chablais,sommet,4,Tête du Géant,Chablais
-750,787.0,http://fr.dbpedia.org/resource/Vieux_Chaillol,Vieux Chaillol,6.18972,44.7356,3163.0,Écrins,sommet,4,Vieux Chaillol,Écrins
-751,788.0,http://fr.dbpedia.org/resource/Cime_de_l'Agnel,Cime de l'Agnel,7.34056,44.1458,2927.0,Mercantour,sommet,0,Cime de l'Agnel,Mercantour
-752,789.0,http://fr.dbpedia.org/resource/Grande_Séolane,Grande Séolane,6.54583,44.3375,2909.0,Trois-Évêchés,sommet,4,Grande Séolane,Trois-Évêchés
-753,790.0,http://fr.dbpedia.org/resource/Mont_Clapier,Mont Clapier,7.42,44.1153,3045.0,Mercantour,sommet,4,Mont Clapier,Mercantour
-754,791.0,http://fr.dbpedia.org/resource/Pic_Sans_Nom,Pic Sans Nom,6.38333,44.8933,3913.0,Écrins,sommet,4,Pic Sans Nom,Écrins
-755,792.0,http://fr.dbpedia.org/resource/Pointe_d'Andey,Pointe d'Andey,6.41806,46.0428,1877.0,Bornes,sommet,4,Pointe d'Andey,Bornes
-756,793.0,http://fr.dbpedia.org/resource/Trois-Évêchés_(sommet),Trois-Évêchés (sommet),6.53417,44.2894,2818.0,Trois-Évêchés,sommet,0,Trois-Évêchés,Trois-Évêchés
-757,794.0,http://fr.dbpedia.org/resource/Aiguille_Croche,Aiguille Croche,6.65917,45.8003,2487.0,Beaufortain,sommet,4,Aiguille Croche,Beaufortain
-758,795.0,http://fr.dbpedia.org/resource/Aiguille_de_Polset,Aiguille de Polset,6.63917,45.2764,3531.0,Vanoise,sommet,4,Aiguille de Polset,Vanoise
-759,796.0,http://fr.dbpedia.org/resource/Aiguille_de_Péclet,Aiguille de Péclet,6.62389,45.2811,3561.0,Vanoise,sommet,4,Aiguille de Péclet,Vanoise
-760,797.0,http://fr.dbpedia.org/resource/Aiguille_du_Fou,Aiguille du Fou,6.91194,45.8972,3501.0,Aiguilles de Chamonix,sommet,4,Aiguille du Fou,Aiguilles de Chamonix
-761,798.0,http://fr.dbpedia.org/resource/Aiguille_du_Grand_Fond,Aiguille du Grand Fond,6.67083,45.6661,2920.0,Beaufortain,sommet,4,Aiguille du Grand Fond,Beaufortain
-762,799.0,http://fr.dbpedia.org/resource/Aiguilles_de_la_Penaz,Aiguilles de la Penaz,6.69944,45.7447,2688.0,Beaufortain,sommet,4,Aiguilles de la Penaz,Beaufortain
-763,800.0,http://fr.dbpedia.org/resource/Cime_de_la_Malédie,Cime de la Malédie,7.39833,44.1222,3059.0,Mercantour,sommet,4,Cime de la Malédie,Mercantour
-764,801.0,http://fr.dbpedia.org/resource/Crêt_du_Rey,Crêt du Rey,6.56583,45.6019,2633.0,Beaufortain,sommet,4,Crêt du Rey,Beaufortain
-765,802.0,http://fr.dbpedia.org/resource/Crête_des_Gittes,Crête des Gittes,6.70833,45.7119,2538.0,Beaufortain,sommet,4,Crête des Gittes,Beaufortain
-766,803.0,http://fr.dbpedia.org/resource/Cuguyons,Cuguyons,6.19972,43.6769,982.0,Préalpes de Castellane,sommet,4,Cuguyons,Préalpes de Castellane
-767,804.0,http://fr.dbpedia.org/resource/Dent_du_Caïman,Dent du Caïman,6.90889,45.8944,3554.0,Aiguilles de Chamonix,sommet,4,Dent du Caïman,Aiguilles de Chamonix
-768,805.0,http://fr.dbpedia.org/resource/Dôme_de_Polset,Dôme de Polset,6.64028,45.2764,3501.0,Vanoise,sommet,4,Dôme de Polset,Vanoise
-769,806.0,http://fr.dbpedia.org/resource/Dôme_de_l'Arpont,Dôme de l'Arpont,6.74278,45.3186,3601.0,Vanoise,sommet,4,Dôme de l'Arpont,Vanoise
-770,807.0,http://fr.dbpedia.org/resource/Dôme_des_Nants,Dôme des Nants,6.74139,45.3264,3570.0,Vanoise,sommet,4,Dôme des Nants,Vanoise
-771,808.0,http://fr.dbpedia.org/resource/Dôme_des_Pichères,Dôme des Pichères,6.79833,45.4917,3319.0,Vanoise,sommet,4,Dôme des Pichères,Vanoise
-772,809.0,http://fr.dbpedia.org/resource/Dôme_des_Sonnailles,Dôme des Sonnailles,6.74556,45.3458,3361.0,Vanoise,sommet,4,Dôme des Sonnailles,Vanoise
-773,810.0,http://fr.dbpedia.org/resource/Grand_Bec,Grand Bec,6.75278,45.4236,3398.0,Vanoise,sommet,4,Grand Bec,Vanoise
-774,811.0,http://fr.dbpedia.org/resource/Grand_Mont,Grand Mont,6.53667,45.6319,2686.0,Beaufortain,sommet,4,Grand Mont,Beaufortain
-775,812.0,http://fr.dbpedia.org/resource/Grand_Roc,Grand Roc,6.68806,45.2656,3316.0,Vanoise,sommet,4,Grand Roc,Vanoise
-776,813.0,http://fr.dbpedia.org/resource/Grand_roc_Noir,Grand roc Noir,6.89167,45.3303,3582.0,Vanoise,sommet,4,Grand roc Noir,Vanoise
-777,814.0,http://fr.dbpedia.org/resource/Grande_Lance_de_Domène,Grande Lance de Domène,5.95917,45.1714,2790.0,Belledonne,sommet,4,Grande Lance de Domène,Belledonne
-778,815.0,http://fr.dbpedia.org/resource/Grande_Parel,Grande Parel,6.64222,45.6272,2725.0,Beaufortain,sommet,4,Grande Parel,Beaufortain
-779,816.0,http://fr.dbpedia.org/resource/Les_Voirons,Les Voirons,6.35528,46.2306,1480.0,Chablais,sommet,4,Les Voirons,Chablais
-780,817.0,http://fr.dbpedia.org/resource/Mont_Joly,Mont Joly,6.69278,45.8258,2525.0,Beaufortain,sommet,4,Mont Joly,Beaufortain
-781,818.0,http://fr.dbpedia.org/resource/Mont_Pelve,Mont Pelve,6.78139,45.3567,3261.0,Vanoise,sommet,4,Mont Pelve,Vanoise
-782,819.0,http://fr.dbpedia.org/resource/Mont_de_Gébroulaz,Mont de Gébroulaz,6.62917,45.2747,3511.0,Vanoise,sommet,4,Mont de Gébroulaz,Vanoise
-783,820.0,http://fr.dbpedia.org/resource/Montagne_de_Lachens,Montagne de Lachens,6.66111,43.7472,1714.0,Préalpes de Castellane,sommet,4,Montagne de Lachens,Préalpes de Castellane
-784,821.0,http://fr.dbpedia.org/resource/Mourre_Nègre,Mourre Nègre,5.46694,43.8153,1125.0,Luberon,sommet,1,Mourre Nègre,Luberon
-785,822.0,http://fr.dbpedia.org/resource/Nivolet,Nivolet,5.96556,45.6139,1547.0,Bauges,sommet,4,Nivolet,Bauges
-786,823.0,http://fr.dbpedia.org/resource/Pic_du_Grand_Doménon,Pic du Grand Doménon,5.97111,45.1617,2802.0,Belledonne,sommet,4,Pic du Grand Doménon,Belledonne
-787,824.0,http://fr.dbpedia.org/resource/Pointe_Rénod,Pointe Rénod,6.60528,45.2458,3368.0,Vanoise,sommet,4,Pointe Rénod,Vanoise
-788,825.0,http://fr.dbpedia.org/resource/Pointe_de_Claret,Pointe de Claret,6.97111,45.3419,3355.0,Vanoise,sommet,4,Pointe de Claret,Vanoise
-789,826.0,http://fr.dbpedia.org/resource/Pointe_de_Méan_Martin,Pointe de Méan Martin,6.99,45.3672,3330.0,Vanoise,sommet,4,Pointe de Méan Martin,Vanoise
-790,827.0,http://fr.dbpedia.org/resource/Pointe_de_Thorens,Pointe de Thorens,6.60944,45.2647,3266.0,Vanoise,sommet,4,Pointe de Thorens,Vanoise
-791,828.0,http://fr.dbpedia.org/resource/Pointe_de_la_Fournache,Pointe de la Fournache,6.7525,45.2875,3642.0,Vanoise,sommet,4,Pointe de la Fournache,Vanoise
-792,829.0,http://fr.dbpedia.org/resource/Pointe_de_la_Grande_Journée,Pointe de la Grande Journée,6.50111,45.6672,2460.0,Beaufortain,sommet,4,Pointe de la Grande Journée,Beaufortain
-793,830.0,http://fr.dbpedia.org/resource/Pointe_de_la_Réchasse,Pointe de la Réchasse,6.80194,45.3733,3212.0,Vanoise,sommet,4,Pointe de la Réchasse,Vanoise
-794,831.0,http://fr.dbpedia.org/resource/Pointe_de_la_Terrasse_(Beaufortain),Pointe de la Terrasse (Beaufortain),6.72444,45.6703,2881.0,Beaufortain,sommet,4,Pointe de la Terrasse,Beaufortain
-795,832.0,http://fr.dbpedia.org/resource/Pointe_des_Buffettes,Pointe des Buffettes,7.00722,45.3656,3233.0,Vanoise,sommet,4,Pointe des Buffettes,Vanoise
-796,833.0,http://fr.dbpedia.org/resource/Pointe_du_Bouchet,Pointe du Bouchet,6.60417,45.2539,3420.0,Vanoise,sommet,4,Pointe du Bouchet,Vanoise
-797,834.0,http://fr.dbpedia.org/resource/Pointe_du_Dard,Pointe du Dard,6.76556,45.3639,3206.0,Vanoise,sommet,4,Pointe du Dard,Vanoise
-798,835.0,http://fr.dbpedia.org/resource/Pointe_du_Vallonnet,Pointe du Vallonnet,6.76083,45.4172,3372.0,Vanoise,sommet,4,Pointe du Vallonnet,Vanoise
-799,836.0,http://fr.dbpedia.org/resource/Pointes_du_Châtelard,Pointes du Châtelard,6.955,45.3317,3479.0,Vanoise,sommet,4,Pointes du Châtelard,Vanoise
-800,837.0,http://fr.dbpedia.org/resource/Roc_des_Saints-Pères,Roc des Saints-Pères,6.61583,45.2789,3470.0,Vanoise,sommet,4,Roc des Saints-Pères,Vanoise
-801,838.0,http://fr.dbpedia.org/resource/Roche_Chevrière,Roche Chevrière,6.72194,45.2933,3281.0,Vanoise,sommet,4,Roche Chevrière,Vanoise
-802,839.0,http://fr.dbpedia.org/resource/Roignais,Roignais,6.68861,45.6431,2995.0,Beaufortain,sommet,0,Roignais,Beaufortain
-803,840.0,http://fr.dbpedia.org/resource/Tête_de_la_Cicle,Tête de la Cicle,6.68667,45.7547,2552.0,Beaufortain,sommet,4,Tête de la Cicle,Beaufortain
-804,841.0,http://fr.dbpedia.org/resource/Épaule_du_Bouchet,Épaule du Bouchet,6.61139,45.2594,3250.0,Vanoise,sommet,4,Épaule du Bouchet,Vanoise
-805,842.0,http://fr.dbpedia.org/resource/Aiguille_de_Blaitière,Aiguille de Blaitière,6.91306,45.8992,3522.0,Aiguilles de Chamonix,sommet,4,Aiguille de Blaitière,Aiguilles de Chamonix
-806,843.0,http://fr.dbpedia.org/resource/Aiguille_du_Grépon,Aiguille du Grépon,6.91917,45.9025,3482.0,Aiguilles de Chamonix,sommet,4,Aiguille du Grépon,Aiguilles de Chamonix
-807,844.0,http://fr.dbpedia.org/resource/Aiguille_du_Plan,Aiguille du Plan,6.90722,45.8917,3673.0,Aiguilles de Chamonix,sommet,4,Aiguille du Plan,Aiguilles de Chamonix
-808,845.0,http://fr.dbpedia.org/resource/Mont_Bichet,Mont Bichet,6.53722,46.2781,1360.0,Chablais,sommet,4,Mont Bichet,Chablais
-809,846.0,http://fr.dbpedia.org/resource/Pointe_d'Areu,Pointe d'Areu,6.57944,45.9817,2478.0,Aravis,sommet,4,Pointe d'Areu,Aravis
-810,847.0,http://fr.dbpedia.org/resource/Aiguille_de_Rochefort,Aiguille de Rochefort,6.96,45.8619,4001.0,Mont-Blanc,sommet,4,Aiguille de Rochefort,Mont-Blanc
-811,848.0,http://fr.dbpedia.org/resource/Aiguille_des_Arias,Aiguille des Arias,6.17167,44.8944,3402.0,Écrins,sommet,2,Aiguille des Arias,Écrins
-812,849.0,http://fr.dbpedia.org/resource/Aiguille_du_Jardin,Aiguille du Jardin,6.97583,45.9339,4035.0,Mont-Blanc,sommet,4,Aiguille du Jardin,Mont-Blanc
-813,850.0,http://fr.dbpedia.org/resource/Aiguilles_du_Diable,Aiguilles du Diable,6.89028,45.8547,4114.0,Mont-Blanc,sommet,1,Aiguilles du Diable,Mont-Blanc
-814,851.0,http://fr.dbpedia.org/resource/Croix_de_Chamrousse,Croix de Chamrousse,5.90247,45.1258,2253.0,Belledonne,sommet,1,Croix de Chamrousse,Belledonne
-815,852.0,http://fr.dbpedia.org/resource/Croix_des_Têtes,Croix des Têtes,6.4425,45.2669,2492.0,Vanoise,sommet,4,Croix des Têtes,Vanoise
-816,853.0,http://fr.dbpedia.org/resource/Dôme_de_Rochefort,Dôme de Rochefort,6.9675,45.8642,4015.0,Mont-Blanc,sommet,4,Dôme de Rochefort,Mont-Blanc
-817,854.0,http://fr.dbpedia.org/resource/Grande_Rocheuse,Grande Rocheuse,6.97278,45.9344,4102.0,Mont-Blanc,sommet,4,Grande Rocheuse,Mont-Blanc
-818,855.0,http://fr.dbpedia.org/resource/Le_Rochail,Le Rochail,6.03111,44.98,3022.0,Écrins,sommet,2,Le Rochail,Écrins
-819,856.0,http://fr.dbpedia.org/resource/Mont_Chéry,Mont Chéry,6.64806,46.1689,1826.0,Chablais,sommet,4,Mont Chéry,Chablais
-820,857.0,http://fr.dbpedia.org/resource/Mont_Mallet,Mont Mallet,6.96056,45.8653,3989.0,Mont-Blanc,sommet,4,Mont Mallet,Mont-Blanc
-821,858.0,http://fr.dbpedia.org/resource/Mont_Orchez,Mont Orchez,6.55056,46.0992,1347.0,Giffre,sommet,4,Mont Orchez,Giffre
-822,859.0,http://fr.dbpedia.org/resource/Mont_Ouzon,Mont Ouzon,6.64444,46.2997,1880.0,Chablais,sommet,4,Mont Ouzon,Chablais
-823,860.0,http://fr.dbpedia.org/resource/Mont_Peney,Mont Peney,5.99,45.5978,1356.0,Bauges,sommet,4,Mont Peney,Bauges
-824,861.0,http://fr.dbpedia.org/resource/Mont_d'Arbois,Mont d'Arbois,6.66944,45.8547,1833.0,Beaufortain,sommet,4,Mont d'Arbois,Beaufortain
-825,862.0,http://fr.dbpedia.org/resource/Mont_d'Hermone,Mont d'Hermone,6.53222,46.3169,1413.0,Chablais,sommet,4,Mont d'Hermone,Chablais
-826,863.0,http://fr.dbpedia.org/resource/Mont_de_Boisy,Mont de Boisy,6.35778,46.3078,739.0,Chablais,sommet,4,Mont de Boisy,Chablais
-827,864.0,http://fr.dbpedia.org/resource/Pic_Lory,Pic Lory,6.35806,44.9219,4088.0,Écrins,sommet,4,Pic Lory,Écrins
-828,865.0,http://fr.dbpedia.org/resource/Pointe_Helbronner,Pointe Helbronner,6.93167,45.8458,3462.0,Mont-Blanc,sommet,4,Pointe Helbronner,Mont-Blanc
-829,866.0,http://fr.dbpedia.org/resource/Pointe_d'Ireuse,Pointe d'Ireuse,6.575,46.2675,1890.0,Chablais,sommet,4,Pointe d'Ireuse,Chablais
-830,867.0,http://fr.dbpedia.org/resource/Pointe_d'Uble,Pointe d'Uble,6.59972,46.1681,1963.0,Chablais,sommet,4,Pointe d'Uble,Chablais
-831,868.0,http://fr.dbpedia.org/resource/Pointe_de_Chalune,Pointe de Chalune,6.58139,46.18,2116.0,Chablais,sommet,4,Pointe de Chalune,Chablais
-832,869.0,http://fr.dbpedia.org/resource/Pointe_de_Chavannais,Pointe de Chavannais,6.54944,46.1792,1851.0,Chablais,sommet,4,Pointe de Chavannais,Chablais
-833,870.0,http://fr.dbpedia.org/resource/Pointe_de_Chavasse,Pointe de Chavasse,6.56917,46.1764,2012.0,Chablais,sommet,4,Pointe de Chavasse,Chablais
-834,871.0,http://fr.dbpedia.org/resource/Pointe_de_Miribel,Pointe de Miribel,6.47417,46.2117,1581.0,Chablais,sommet,4,Pointe de Miribel,Chablais
-835,872.0,http://fr.dbpedia.org/resource/Pointe_de_la_Gay,Pointe de la Gay,6.57306,46.2297,1801.0,Chablais,sommet,4,Pointe de la Gay,Chablais
-836,873.0,http://fr.dbpedia.org/resource/Pointe_des_Brasses,Pointe des Brasses,6.44278,46.1633,1503.0,Chablais,sommet,4,Pointe des Brasses,Chablais
-837,874.0,http://fr.dbpedia.org/resource/Pointe_du_Vallon_des_Étages,Pointe du Vallon des Étages,6.26889,44.8853,3564.0,Écrins,sommet,4,Pointe du Vallon des Étages,Écrins
-838,875.0,http://fr.dbpedia.org/resource/Sur_la_Pointe,Sur la Pointe,6.54333,46.235,1657.0,Chablais,sommet,4,Sur la Pointe,Chablais
-839,876.0,http://fr.dbpedia.org/resource/Tête_de_Lauranoure,Tête de Lauranoure,6.15139,44.9261,3325.0,Écrins,sommet,4,Tête de Lauranoure,Écrins
-840,877.0,http://fr.dbpedia.org/resource/Aiguille_de_Leschaux,Aiguille de Leschaux,7.00667,45.8872,3759.0,Mont-Blanc,sommet,4,Aiguille de Leschaux,Mont-Blanc
-841,878.0,http://fr.dbpedia.org/resource/Aiguille_de_Talèfre,Aiguille de Talèfre,7.00389,45.8997,3730.0,Mont-Blanc,sommet,4,Aiguille de Talèfre,Mont-Blanc
-842,879.0,http://fr.dbpedia.org/resource/Aiguille_de_la_Floria,Aiguille de la Floria,6.86861,45.9761,2888.0,Aiguilles Rouges,sommet,4,Aiguille de la Floria,Aiguilles Rouges
-843,880.0,http://fr.dbpedia.org/resource/Grand_Capelet,Grand Capelet,7.42722,44.0783,2935.0,Mercantour,sommet,4,Grand Capelet,Mercantour
-844,881.0,http://fr.dbpedia.org/resource/Le_Drouvet,Le Drouvet,6.3175,44.7211,2655.0,Écrins,sommet,4,Le Drouvet,Écrins
-845,882.0,http://fr.dbpedia.org/resource/Levanna,Levanna,7.17194,45.4103,3619.0,Alpes grées,sommet,4,Levanna,Alpes grées
-846,883.0,http://fr.dbpedia.org/resource/Mont_Lachat,Mont Lachat,6.35139,45.9275,2023.0,Bornes,sommet,4,Mont Lachat,Bornes
-847,884.0,http://fr.dbpedia.org/resource/Mont_Tondu,Mont Tondu,6.75528,45.7636,3196.0,Mont-Blanc,sommet,4,Mont Tondu,Mont-Blanc
-848,885.0,http://fr.dbpedia.org/resource/Pointe_des_Estaris,Pointe des Estaris,6.34167,44.7425,3086.0,Écrins,sommet,2,Pointe des Estaris,Écrins
-849,886.0,http://fr.dbpedia.org/resource/Baou_des_Blancs,Baou des Blancs,7.10903,43.7341,673.0,Préalpes de Castellane,sommet,4,Baou des Blancs,Préalpes de Castellane
-850,887.0,http://fr.dbpedia.org/resource/Baou_des_Noirs,Baou des Noirs,7.12389,43.7431,678.0,Préalpes de Castellane,sommet,4,Baou des Noirs,Préalpes de Castellane
-851,888.0,http://fr.dbpedia.org/resource/Croix_Rousse_(montagne),Croix Rousse (montagne),7.13194,45.2608,3541.0,Alpes grées,sommet,4,Croix Rousse,Alpes grées
-852,889.0,http://fr.dbpedia.org/resource/Grun_de_Saint-Maurice,Grun de Saint-Maurice,6.05639,44.8158,2775.0,Écrins,sommet,4,Grun de Saint-Maurice,Écrins
-853,890.0,http://fr.dbpedia.org/resource/Mont_Beauvoir,Mont Beauvoir,5.79167,45.4767,1320.0,Chartreuse,sommet,4,Mont Beauvoir,Chartreuse
-854,891.0,http://fr.dbpedia.org/resource/Pointe_de_la_Gorgeat,Pointe de la Gorgeat,5.89389,45.4967,1486.0,Chartreuse,sommet,4,Pointe de la Gorgeat,Chartreuse
-855,892.0,http://fr.dbpedia.org/resource/Puy_de_Rent,Puy de Rent,6.59028,44.0211,1996.0,Préalpes de Castellane,sommet,4,Puy de Rent,Préalpes de Castellane
-856,893.0,http://fr.dbpedia.org/resource/Colline_de_Lémenc,Colline de Lémenc,5.9325,45.5956,558.0,Bauges,sommet,4,Colline de Lémenc,Bauges
-857,894.0,http://fr.dbpedia.org/resource/Grand_Assaly,Grand Assaly,6.97028,45.6542,3173.0,Alpes grées,sommet,4,Grand Assaly,Alpes grées
-858,895.0,http://fr.dbpedia.org/resource/Gros_Rognon,Gros Rognon,6.90444,45.8683,3541.0,Mont-Blanc,sommet,4,Gros Rognon,Mont-Blanc
-859,896.0,http://fr.dbpedia.org/resource/Le_Grand_Manti,Le Grand Manti,5.90861,45.3847,1818.0,Chartreuse,sommet,4,Le Grand Manti,Chartreuse
-860,897.0,http://fr.dbpedia.org/resource/Mont_Ventoux,Mont Ventoux,5.27889,44.1744,1911.0,"",sommet,0,Mont Ventoux,""
-861,898.0,http://fr.dbpedia.org/resource/Sommarel,Sommarel,5.90047,44.6463,2400.0,"",sommet,4,Sommarel,""
-862,899.0,http://fr.dbpedia.org/resource/Pointe_de_Platé,Pointe de Platé,6.73056,45.9653,2554.0,"",sommet,4,Pointe de Platé,""
-863,900.0,http://fr.dbpedia.org/resource/Aiguille_de_Varan,Aiguille de Varan,6.68278,45.9583,2544.0,"",sommet,4,Aiguille de Varan,""
-864,,,Gap,6.079432600191486,44.5595869312691,,,ville,0,Gap,
-865,,,Embrun,6.495560952335447,44.56485713871447,,,ville,0,Embrun,
-866,,,Les Orres,6.554023109652923,44.49710763054921,1650.0,Parpaillon,ski,0,Les Orres,
-867,,,Chorges,6.276323633649868,44.54684852025204,,,ville,1,Chorges,
-868,,,Guillestre,6.650791503505738,44.66114868605746,,Queyras,ville,1,Guillestre,
-869,,,Mont-Dauphin,6.624269832997856,44.669493230269616,,,ville,2,Mont-Dauphin,
-870,,,Saint-Véran,6.867500171819265,44.70124760646876,1600.0,Queyras,ville,1,Saint-Véran,
-871,,,Orcières-Merlette,6.321416837471743,44.69795943724613,1850.0,Ecrins,ski,0,Orcières-Merlette,
-872,,,Saint-Gervais-Mont-Blanc,6.713875115750719,45.89523558940015,,,ville,0,Saint-Gervais-Mont-Blanc,
-873,,,Evian-les-Bains,6.592257987599584,46.40205540657058,,,ville,0,Evian-les-Bains,
-874,,,Thonon-les-Bains,6.49418058524078,46.37995284211109,,,ville,0,Thonon-les-Bains,
-875,,,Annecy,6.130031814106662,45.90967706383779,,,ville,0,Annecy,
-876,,,Annemasse,6.248501547648977,46.19474450898318,,,ville,0,Annemasse,
-877,,,Megève,6.620418825900607,45.8630371065899,,,,0,Megève,
-878,,,Albertville,6.387765837722875,45.67568515211394,,,ville,0,Albertville,
-879,,,Moûtiers,6.53001320389735,45.48607909506519,,,ville,1,Moûtiers,
-880,,,Chambéry,5.92092764127429,45.56641121820684,,,ville,0,Chambéry,
-881,,,La Motte-Servolex,5.878236972339251,45.59954343016685,,,ville,1,La Motte-Servolex,
-882,,,Lac d'Aiguebelette,5.79793758689749,45.55178442239692,,,lac,1,Lac d'Aiguebelette,
-883,,,Pontcharra,6.031241388107246,45.434921905136086,,,ville,1,Pontcharra,
-884,,,Grenoble,5.719112613284874,45.19153079540343,,,ville,0,Grenoble,
-885,,,Die,5.367118334566535,44.7579343447296,,,ville,0,Die,
-886,,,Châtillon-en-Diois,5.490792000062169,44.69517231733398,,,ville,1,Châtillon-en-Diois,
-887,,,Laragne-Montéglin,5.829195766088718,44.31879082051636,,,ville,1,Laragne-Montéglin,
-888,,,Sisteron,5.943809089789812,44.19712096507554,,,ville,0,Sisteron,
-889,,,Digne-les-Bains,6.233710760204239,44.095153578516765,,,ville,0,Digne-les-Bains,
-890,,,Allos,6.626245206238759,44.24632022452225,,,ville,1,Allos,
-891,,,Saint-Etienne-de-Tinée,6.9253327302635865,44.264403514957145,,,ville,0,Saint-Etienne-de-Tinée,
-892,,,Saint-Martin-Vésubie,7.257864134754573,44.07268569247778,,,ville,0,Saint-Martin-Vésubie,
-893,,,Tende,7.595162687330365,44.090903551858034,,,ville,0,Tende,
-894,,,Isola 2000,7.160156965255738,44.185412243069976,,,ski,0,Isola 2000,
-895,,,Barcelonnette,6.652467594207009,44.38679591872338,,,ville,0,Barcelonnette,
-896,,,Le Sauze,6.68066883915262,44.373057293422725,,,ski,1,Le Sauze,
-897,,,Saint-Paul-sur-Ubaye,6.751752022298497,44.51546859224411,,,ville,1,Saint-Paul-sur-Ubaye,
-898,,,Larche,6.846105366985783,44.45172243053217,,,ville,1,Larche,
-899,,,Mont Viso,7.076124167338565,44.681692334362346,3150.0,,sommet,0,Mont Viso,
-900,,,Château Queyras,6.795452334606803,44.75816857295474,,,ville,1,Château Queyras,
-901,,,Mont-Dauphin,6.622576259414445,44.66910893510975,,,ville,1,Mont-Dauphin,
-902,,,Réallon,6.364278587164024,44.59582343991221,,,ville,2,Réallon,
-903,,,Savines-le-Lac,6.405107455780029,44.52584629850958,,,ville,1,Savines-le-Lac,
-904,,,Saint-Jean-de-Maurienne,6.34614361106281,45.27641383802331,,,ville,0,Saint-Jean-de-Maurienne,
-905,,,Saint-Michel-de-Maurienne,6.47381604416872,45.21834117256122,,,ville,1,Saint-Michel-de-Maurienne,
-906,,,Modane,6.677696775148557,45.20493808757215,,,ville,0,Modane,
-907,,,Ugine,6.424913239080557,45.74812394884372,,,ville,1,Ugine,
-908,,,Bourg d'Oisans,6.0289763026586005,45.05984415198453,,,ville,0,Bourg d'Oisans,
-909,,,La Chapelle-en-Valgaudemar,6.204545847763467,44.81906459548416,,,ville,1,La Chapelle-en-Valgaudemar,
-910,,,Auron,6.92593708338909,44.22158612630177,,,ski,1,Auron,
-911,,,Ristolas,6.954802653304895,44.77482386687705,,,ville,2,Ristolas,
-912,,,Abriès,6.92753980037114,44.794623911381606,,,ville,2,Abriès,
-913,,,Briançon,6.644185734271445,44.89964981204464,,,ville,0,Briançon,
-914,,,Névache,6.610107202646259,45.02034244983677,,,ville,1,Névache,
-915,,,Le Monétier-les-Bains,6.509086708829712,44.97685437584322,,,ville,2,Le Monétier-les-Bains,
-916,,,Les Contamines-Montjoie,6.729091591806778,45.82252717690924,,,ville,1,Les Contamines-Montjoie,
-917,,"",Bourg-Saint-Maurice,6.7680574366519695,45.616137255196975,,,ville,0,Bourg-Saint-Maurice,
-918,,,Sainte-Foy-Tarentaise,6.884334129135975,45.59180985239221,,,ville,1,Sainte-Foy-Tarentaise,
-919,,,Cluses,6.581036552262885,46.06311628337413,,,ville,0,Cluses,
-920,,,Séchilienne,5.844316911130973,45.05730375511637,,,ville,1,Séchilienne,
-921,,,Aiguebelle,6.310101420085662,45.54488960620396,,,ville,1,Aiguebelle,
-922,,,Courmayeur,6.9722775769324725,45.7935744843519,,,ville,0,Courmayeur,
-923,,,Col du Grand Saint-Bernard,7.165925948593418,45.869293911934285,,,col,0,Col du Grand Saint-Bernard,
-924,,,Aoste,7.32294747546813,45.73890011412526,,,ville,0,Aoste,
-925,,,Cogne,7.354040451781102,45.61124687864208,,,ville,0,Cogne,
-926,,,Bardonnèche,6.710391316970503,45.08174295346145,,,ville,0,Bardonnèche,
-927,,,Oulx,6.83422484172109,45.03522010591207,,,ville,0,Oulx,
-928,,,Sestrières,6.882338504203791,44.96020251331485,,,,0,Sestrières,
-929,,,Limone,7.577817551648539,44.20448386397838,,,ville,1,Limone,
+,url,name,lon,lat,altitude,range,category,group,short_name,hint
+878,0,Albertville,6.387765837722875,45.67568515211394,0.0,0,ville,0,Albertville,Savoie
+875,0,Annecy,6.130031814106662,45.90967706383779,0.0,0,ville,0,Annecy,
+876,0,Annemasse,6.248501547648977,46.19474450898318,0.0,0,ville,0,Annemasse,
+924,0,Aoste,7.32294747546813,45.73890011412526,0.0,0,ville,0,Aoste,
+224,http://fr.dbpedia.org/resource/Avoriaz,Avoriaz,6.76853,46.1945,1800.0,0,ski,0,Avoriaz,Haute-Savoie
+895,0,Barcelonnette,6.652467594207009,44.38679591872338,0.0,0,ville,0,Barcelonnette,Ubaye
+518,http://fr.dbpedia.org/resource/Dôme_de_Neige_des_Écrins,Barre des Écrins,6.359291300601373,44.92219456036066,4100.0,Écrins,sommet,0,Barre des Écrins,
+917,0,Bourg-Saint-Maurice,6.7680574366519695,45.616137255196975,0.0,0,ville,0,Bourg-Saint-Maurice,Tarentaise
+913,0,Briançon,6.644185734271445,44.89964981204464,0.0,0,ville,0,Briançon,
+880,0,Chambéry,5.92092764127429,45.56641121820684,0.0,0,ville,0,Chambéry,
+245,http://fr.dbpedia.org/resource/Chamonix-Mont-Blanc,Chamonix-Mont-Blanc,6.86972,45.9231,0.0,0,ski,0,Chamonix,Mont-Blanc
+182,http://fr.dbpedia.org/resource/Chamrousse,Chamrousse,5.87444,45.1092,1700.0,Belledonne,ski,0,Chamrousse,Belledonne
+21,http://fr.dbpedia.org/resource/Col_d'Izoard,Col d'Izoard,6.73526,44.8196,2361.0,Queyras,col,0,Col d'Izoard,Queyras
+22,http://fr.dbpedia.org/resource/Col_de_l'Iseran,Col de l'Iseran,7.03146,45.4173,2764.0,Vanoise,col,0,Col de l'Iseran,Vanoise
+172,http://fr.dbpedia.org/resource/Col_du_Galibier,Col du Galibier,6.40862,45.0643,2642.0,0,col,0,Col du Galibier,Écrins
+192,http://fr.dbpedia.org/resource/Courchevel,Courchevel,6.63474,45.4159,1110.0,Vanoise,ski,0,Courchevel,Tarentaise
+378,http://fr.dbpedia.org/resource/Dent_de_Crolles,Dent de Crolles,5.85528,45.3083,2062.0,Chartreuse,sommet,0,Dent de Crolles,Chartreuse
+889,0,Digne-les-Bains,6.233710760204239,44.095153578516765,0.0,0,ville,0,Digne-les-Bains,
+865,0,Embrun,6.495560952335447,44.56485713871447,0.0,0,ville,0,Embrun,
+873,0,Evian-les-Bains,6.592257987599584,46.40205540657058,0.0,0,ville,0,Evian-les-Bains,
+864,0,Gap,6.079432600191486,44.5595869312691,0.0,0,ville,0,Gap,
+440,http://fr.dbpedia.org/resource/Grandes_Jorasses,Grandes Jorasses,6.98806,45.8689,4208.0,Mont-Blanc,sommet,0,Grandes Jorasses,Mont-Blanc
+884,0,Grenoble,5.719112613284874,45.19153079540343,0.0,0,ville,0,Grenoble,
+173,http://fr.dbpedia.org/resource/Col_de_la_Croix-Haute,Lus-la-Croix-Haute,5.706018612643958,44.66581196177503,1176.0,0,col,0,Lus-la-Croix-Haute,Trièves
+877,0,Megève,6.620418825900607,45.8630371065899,0.0,0,0,0,Megève,
+906,0,Modane,6.677696775148557,45.20493808757215,0.0,0,ville,0,Modane,Maurienne
+445,http://fr.dbpedia.org/resource/Mont_Aiguille,Mont Aiguille,5.55306,44.8419,2087.0,Vercors,sommet,0,Mont Aiguille,Vercors
+437,http://fr.dbpedia.org/resource/Mont_Blanc,Mont Blanc,6.86472,45.8326,4810.02,Mont-Blanc,sommet,0,Mont Blanc,Mont-Blanc
+392,http://fr.dbpedia.org/resource/Mont_Bégo,Mont Bégo,7.45083,44.0731,2872.0,Mercantour,sommet,0,Mont Bégo,Mercantour
+860,http://fr.dbpedia.org/resource/Mont_Ventoux,Mont Ventoux,5.27889,44.1744,1911.0,0,sommet,0,Mont Ventoux,
+899,0,Mont Viso,7.076124167338565,44.681692334362346,3150.0,0,sommet,0,Mont Viso,
+904,0,Saint-Jean-de-Maurienne,6.34614361106281,45.27641383802331,0.0,0,ville,0,Saint-Jean-de-Maurienne,
+874,0,Thonon-les-Bains,6.49418058524078,46.37995284211109,0.0,0,ville,0,Thonon-les-Bains,
+756,http://fr.dbpedia.org/resource/Trois-Évêchés_(sommet),Trois-Évêchés (sommet),6.53417,44.2894,2818.0,Trois-Évêchés,sommet,0,Trois-Évêchés,Trois-Évêchés
+277,http://fr.dbpedia.org/resource/Villard-de-Lans,Villard-de-Lans,5.55139,45.0708,0.0,0,ski,0,Villard-de-Lans,Vercors
+260,http://fr.dbpedia.org/resource/Abondance_(Haute-Savoie),Abondance,6.72278,46.2797,0.0,0,ski,1,Abondance,
+371,http://fr.dbpedia.org/resource/Aiguille_du_Midi,Aiguille du Midi,6.88722,45.8786,3842.0,Mont-Blanc,sommet,1,Aiguille du Midi,Mont-Blanc
+375,http://fr.dbpedia.org/resource/Aiguilles_d'Arves,Aiguilles d'Arves,6.33444,45.1231,3514.0,Arves,sommet,1,Aiguilles d'Arves,Arves
+280,http://fr.dbpedia.org/resource/Argentière,Argentière,6.921515464782715,45.97567094185704,0.0,0,ski,1,Argentière,
+256,http://fr.dbpedia.org/resource/Autrans,Autrans,5.54278,45.1758,0.0,0,ski,1,Autrans,Vercors
+926,0,Bardonnèche,6.710391316970503,45.08174295346145,0.0,0,ville,1,Bardonnèche,
+258,http://fr.dbpedia.org/resource/Beaufort_(Savoie),Beaufort,6.57556,45.7189,0.0,0,ski,1,Beaufort,Beaufortain
+908,0,Bourg d'Oisans,6.0289763026586005,45.05984415198453,0.0,0,ville,1,Bourg d'Oisans,Oisans
+751,http://fr.dbpedia.org/resource/Cime_de_l'Agnel,Cime de l'Agnel,7.34056,44.1458,2927.0,Mercantour,sommet,1,Cime de l'Agnel,Mercantour
+919,0,Cluses,6.581036552262885,46.06311628337413,0.0,0,ville,1,Cluses,
+925,0,Cogne,7.354040451781102,45.61124687864208,0.0,0,ville,1,Cogne,Val d'Aoste
+59,http://fr.dbpedia.org/resource/Col_de_Joux_Plane,Col de Joux Plane,6.71278,46.1297,1691.0,Chablais,col,1,Col de Joux Plane,Chablais
+29,http://fr.dbpedia.org/resource/Col_de_Montgenèvre,Col de Montgenèvre,6.72333,44.9308,1850.0,Queyras,col,1,Col de Montgenèvre,Queyras
+99,http://fr.dbpedia.org/resource/Col_de_Rousset,Col de Rousset,5.406,44.8406,1254.0,Vercors,col,1,Col de Rousset,Vercors
+30,http://fr.dbpedia.org/resource/Col_de_Tende,Col de Tende,7.56197,44.1492,1871.0,Alpes ligures,col,1,Col de Tende,Alpes ligures
+68,http://fr.dbpedia.org/resource/Col_de_Turini,Col de Turini,7.3917,43.9778,1604.0,Préalpes de Nice,col,1,Col de Turini,Préalpes de Nice
+31,http://fr.dbpedia.org/resource/Col_de_Vars,Col de Vars,6.70278,44.5392,2108.0,Parpaillon,col,1,Col de Vars,Parpaillon
+102,http://fr.dbpedia.org/resource/Col_de_la_Croix-de-Fer,Col de la Croix-de-Fer,6.20373,45.2278,2068.0,Grandes Rousses,col,1,Col de la Croix-de-Fer,Grandes Rousses
+103,http://fr.dbpedia.org/resource/Col_de_la_Madeleine,Col de la Madeleine,6.37556,45.4353,1993.0,Vanoise,col,1,Col de la Madeleine,Vanoise
+96,http://fr.dbpedia.org/resource/Col_des_Saisies,Col des Saisies,6.52861,45.7583,1633.0,Beaufortain,col,1,Col des Saisies,Beaufortain
+923,0,Col du Grand Saint-Bernard,7.165925948593418,45.869293911934285,0.0,0,col,1,Col du Grand Saint-Bernard,
+25,http://fr.dbpedia.org/resource/Col_du_Lautaret,Col du Lautaret,6.4055,45.0353,2058.0,Écrins,col,1,Col du Lautaret,Écrins
+110,http://fr.dbpedia.org/resource/Col_du_Mont-Cenis,Col du Mont-Cenis,6.9009,45.2602,2081.0,Mont-Cenis,col,1,Col du Mont-Cenis,Mont-Cenis
+56,http://fr.dbpedia.org/resource/Col_du_Petit-Saint-Bernard,Col du Petit-Saint-Bernard,6.88395,45.6803,2188.0,Mont-Blanc,col,1,Col du Petit-Saint-Bernard,Tarentaise
+922,0,Courmayeur,6.9722775769324725,45.7935744843519,0.0,0,ville,1,Courmayeur,Val d'Aoste
+439,http://fr.dbpedia.org/resource/Croix_de_Belledonne,Croix de Belledonne,5.98833,45.1686,2926.0,Belledonne,sommet,1,Croix de Belledonne,Belledonne
+885,0,Die,5.367118334566535,44.7579343447296,0.0,0,ville,1,Die,
+520,http://fr.dbpedia.org/resource/Grande_Casse,Grande Casse,6.8275,45.4053,3855.0,Vanoise,sommet,1,Grande Casse,Vanoise
+389,http://fr.dbpedia.org/resource/Grande_Tête_de_l'Obiou,Grande Tête de l'Obiou,5.83944,44.7753,2789.0,Dévoluy,sommet,1,Grande Tête de l'Obiou,Dévoluy
+230,http://fr.dbpedia.org/resource/Gresse-en-Vercors,Gresse-en-Vercors,5.5675,44.9031,1250.0,0,ski,1,Gresse-en-Vercors,
+894,0,Isola 2000,7.160156965255738,44.185412243069976,0.0,0,ski,1,Isola 2000,
+193,http://fr.dbpedia.org/resource/L'Alpe_d'Huez,L'Alpe d'Huez,6.07139,45.0936,1850.0,Grandes Rousses,ski,1,L'Alpe d'Huez,Oisans
+223,http://fr.dbpedia.org/resource/La_Clusaz,La Clusaz,6.42389,45.905,1040.0,0,ski,1,La Clusaz,
+441,http://fr.dbpedia.org/resource/La_Meije,La Meije,6.30861,45.0047,3983.0,Écrins,sommet,1,La Meije,Écrins
+207,http://fr.dbpedia.org/resource/La_Plagne,La Plagne,6.67722,45.5064,0.0,Vanoise,ski,1,La Plagne,Tarentaise
+932,,,6.172758603253082,45.8562744435958,,,lac,1,Lac d'Annecy,
+931,,Lac du Bourget,5.862989381941649,45.73643917984985,,,lac,1,Lac du Bourget,
+198,http://fr.dbpedia.org/resource/Les_Arcs_(Savoie),Les Arcs (Savoie),6.8077,45.5716,813.0,Vanoise,ski,1,Les Arcs,Tarentaise
+215,http://fr.dbpedia.org/resource/Les_Carroz_d'Arâches,Les Carroz d'Arâches,6.64361,46.025,0.0,Alpes,ski,1,Les Carroz d'Arâches,
+184,http://fr.dbpedia.org/resource/Les_Deux_Alpes,Les Deux Alpes,6.12539,45.0115,1650.0,Écrins,ski,1,Les Deux Alpes,Oisans
+181,http://fr.dbpedia.org/resource/Les_Menuires,Les Menuires,6.5375,45.3244,1850.0,Vanoise,ski,1,Les Menuires,Vanoise
+866,0,Les Orres,6.554023109652923,44.49710763054921,1650.0,Parpaillon,ski,1,Les Orres,
+214,http://fr.dbpedia.org/resource/Les_Sept_Laux,Les Sept Laux,5.9931,45.2557,0.0,Belledonne,ski,1,Les Sept Laux,Belledonne
+446,http://fr.dbpedia.org/resource/Mont_Granier,Mont Granier,5.92528,45.4647,1933.0,Chartreuse,sommet,1,Mont Granier,Chartreuse
+447,http://fr.dbpedia.org/resource/Mont_Pelvoux,Mont Pelvoux,6.39333,44.8981,3946.0,Écrins,sommet,1,Mont Pelvoux,Écrins
+379,http://fr.dbpedia.org/resource/Mont_Pourri,Mont Pourri,6.86,45.5283,3779.0,Vanoise,sommet,1,Mont Pourri,Vanoise
+404,http://fr.dbpedia.org/resource/Mont_Thabor_(France),Mont Thabor,6.56389,45.1142,3178.0,Cerces,sommet,1,Mont Thabor,Cerces
+380,http://fr.dbpedia.org/resource/Montagne_de_Lure,Montagne de Lure,5.80278,44.1233,1826.0,Monts de Vaucluse,sommet,1,Montagne de Lure,
+180,http://fr.dbpedia.org/resource/Méribel,Méribel,6.56627,45.3967,1026.0,Vanoise,ski,1,Méribel,Vanoise
+871,0,Orcières-Merlette,6.321416837471743,44.69795943724613,1850.0,Ecrins,ski,1,Orcières-Merlette,Écrins
+927,0,Oulx,6.83422484172109,45.03522010591207,0.0,0,ville,1,Oulx,
+319,http://fr.dbpedia.org/resource/Pain_de_Sucre_(Queyras),Pain de Sucre,6.99639,44.6903,3208.0,Escreins,sommet,1,Pain de Sucre,Queyras
+891,0,Saint-Etienne-de-Tinée,6.9253327302635865,44.264403514957145,0.0,0,ville,1,Saint-Etienne-de-Tinée,
+872,0,Saint-Gervais-Mont-Blanc,6.713875115750719,45.89523558940015,0.0,0,ville,1,Saint-Gervais-Mont-Blanc,
+892,0,Saint-Martin-Vésubie,7.257864134754573,44.07268569247778,0.0,0,ville,1,Saint-Martin-Vésubie,
+178,http://fr.dbpedia.org/resource/Saint-Pierre-de-Chartreuse,Saint-Pierre-de-Chartreuse,5.81611,45.3433,900.0,0,ski,1,Saint-Pierre-de-Chartreuse,
+928,0,Sestrières,6.882338504203791,44.96020251331485,0.0,0,0,1,Sestrières,
+888,0,Sisteron,5.943809089789812,44.19712096507554,0.0,0,ville,1,Sisteron,
+570,http://fr.dbpedia.org/resource/Taillefer_(sommet),Taillefer (sommet),5.92419,45.0394,2857.0,Taillefer,sommet,1,Taillefer,Taillefer
+233,http://fr.dbpedia.org/resource/Tignes,Tignes,6.91389,45.4733,2100.0,0,ski,1,Tignes,Vanoise
+450,http://fr.dbpedia.org/resource/Tête_de_l'Estrop,Tête de l'Estrop,6.50472,44.2872,2961.0,Trois-Évêchés,sommet,1,Tête de l'Estrop,Trois-Évêchés
+289,http://fr.dbpedia.org/resource/Val_Cenis_Vanoise,Val Cenis,6.894,45.286,0.0,0,ski,1,Val Cenis,Haute-Maurienne
+183,http://fr.dbpedia.org/resource/Val_Thorens,Val Thorens,6.57972,45.2983,2300.0,Vanoise,ski,1,Val Thorens,Vanoise
+222,http://fr.dbpedia.org/resource/Val-d'Isère,Val-d'Isère,6.97806,45.4506,1850.0,0,ski,1,Val-d'Isère,Vanoise
+221,http://fr.dbpedia.org/resource/Valloire,Valloire,6.42917,45.1658,1430.0,0,ski,1,Valloire,Maurienne
+930,,,5.827157189184913,44.53651624636477,,,ville,1,Veynes,Dévoluy
+890,0,Allos,6.626245206238759,44.24632022452225,0.0,0,ville,2,Allos,
+281,http://fr.dbpedia.org/resource/Bonneval-sur-Arc,Bonneval-sur-Arc,7.04722,45.3722,0.0,0,ski,2,Bonneval-sur-Arc,Haute-Maurienne
+867,0,Chorges,6.276323633649868,44.54684852025204,0.0,0,ville,2,Chorges,
+900,0,Château Queyras,6.795452334606803,44.75816857295474,0.0,0,ville,2,Château Queyras,
+886,0,Châtillon-en-Diois,5.490792000062169,44.69517231733398,0.0,0,ville,2,Châtillon-en-Diois,
+28,http://fr.dbpedia.org/resource/Col_de_Larche,Col de Larche,6.8985,44.4218,1194.0,Chambeyron,col,2,Col de Larche,Chambeyron
+61,http://fr.dbpedia.org/resource/Col_de_Vence_(Alpes-Maritimes),Col de Vence,7.07528,43.7606,962.0,Préalpes de Castellane,col,2,Col de Vence,Préalpes de Castellane
+55,http://fr.dbpedia.org/resource/Col_des_Aravis,Col des Aravis,6.46472,45.8725,1486.0,Aravis,col,2,Col des Aravis,Aravis
+107,http://fr.dbpedia.org/resource/Col_du_Glandon,Col du Glandon,6.1758,45.2394,1924.0,Arves,col,2,Col du Glandon,Arves
+111,http://fr.dbpedia.org/resource/Col_du_Télégraphe,Col du Télégraphe,6.44531,45.2025,1566.0,Cerces,col,2,Col du Télégraphe,Cerces
+549,http://fr.dbpedia.org/resource/Dent_Parrachée,Dent Parrachée,6.75611,45.2919,3697.0,Vanoise,sommet,2,Dent Parrachée,Vanoise
+519,http://fr.dbpedia.org/resource/Grand_Som,Grand Som,5.81194,45.3706,2026.0,Chartreuse,sommet,2,Grand Som,Chartreuse
+388,http://fr.dbpedia.org/resource/Grand_Veymont,Grand Veymont,5.52694,44.87,2341.0,Vercors,sommet,2,Grand Veymont,Vercors
+691,http://fr.dbpedia.org/resource/Grande_Lauzière,Grande Lauzière,5.95889,45.1569,2741.0,Belledonne,sommet,2,Grande Lauzière,Belledonne
+521,http://fr.dbpedia.org/resource/Grande_Moucherolle,Grande Moucherolle,5.56417,45.0053,2284.0,Vercors,sommet,2,Grande Moucherolle,Vercors
+868,0,Guillestre,6.650791503505738,44.66114868605746,0.0,Queyras,ville,2,Guillestre,
+204,http://fr.dbpedia.org/resource/La_Norma,La Norma,6.69889,45.2022,1350.0,Maurienne,ski,2,La Norma,
+189,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.42583,45.9425,1000.0,Aravis,ski,2,Le Grand-Bornand,
+896,0,Le Sauze,6.68066883915262,44.373057293422725,0.0,0,ski,2,Le Sauze,
+929,0,Limone,7.577817551648539,44.20448386397838,0.0,0,ville,2,Limone,
+869,0,Mont-Dauphin,6.624269832997856,44.669493230269616,0.0,0,ville,2,Mont-Dauphin,
+901,0,Mont-Dauphin,6.622576259414445,44.66910893510975,0.0,0,ville,2,Mont-Dauphin,
+300,http://fr.dbpedia.org/resource/Montagne_de_Céüse,Montagne de Céüse,5.96167,44.5086,2016.0,Bochaine,sommet,2,Montagne de Céüse,Bochaine
+879,0,Moûtiers,6.53001320389735,45.48607909506519,0.0,0,ville,2,Moûtiers,
+914,0,Névache,6.610107202646259,45.02034244983677,0.0,0,ville,2,Névache,Clarée
+320,http://fr.dbpedia.org/resource/Pic_de_Morgon,Pic de Morgon,6.3975,44.4917,2324.0,Parpaillon,sommet,2,Pic de Morgon,Parpaillon
+677,http://fr.dbpedia.org/resource/Pointe_Percée,Pointe Percée,6.55556,45.9558,2750.0,Aravis,sommet,2,Pointe Percée,Aravis
+303,http://fr.dbpedia.org/resource/Pointe_des_Cerces,Pointe des Cerces,6.4876,45.0658,3097.0,Cerces,sommet,2,Pointe des Cerces,Cerces
+700,http://fr.dbpedia.org/resource/Pointe_du_Fréjus,Tunnel de Fréjus,6.68028,45.1403,2934.0,Mont-Cenis,autre,2,Pointe du Fréjus,
+802,http://fr.dbpedia.org/resource/Roignais,Roignais,6.68861,45.6431,2995.0,Beaufortain,sommet,2,Roignais,Beaufortain
+870,0,Saint-Véran,6.867500171819265,44.70124760646876,1600.0,Queyras,ville,2,Saint-Véran,
+893,0,Tende,7.595162687330365,44.090903551858034,0.0,0,ville,2,Tende,
+322,http://fr.dbpedia.org/resource/Tête_de_Vautisse,Tête de Vautisse,6.48528,44.7011,3156.0,Écrins,sommet,2,Tête de Vautisse,Écrins
+544,http://fr.dbpedia.org/resource/Tête_de_l'Étret,Tête de l'Étret,6.24472,44.8894,3559.0,Écrins,sommet,2,Tête de l'Étret,Écrins
+921,0,Aiguebelle,6.310101420085662,45.54488960620396,0.0,0,ville,3,Aiguebelle,
+658,http://fr.dbpedia.org/resource/Aiguille_de_Bionnassay,Aiguille de Bionnassay,6.81806,45.8358,4052.0,Mont-Blanc,sommet,3,Aiguille de Bionnassay,Mont-Blanc
+813,http://fr.dbpedia.org/resource/Aiguilles_du_Diable,Aiguilles du Diable,6.89028,45.8547,4114.0,Mont-Blanc,sommet,3,Aiguilles du Diable,Mont-Blanc
+910,0,Auron,6.92593708338909,44.22158612630177,0.0,0,ski,3,Auron,
+662,http://fr.dbpedia.org/resource/Chamechaude,Chamechaude,5.78806,45.2875,2082.0,Chartreuse,sommet,3,Chamechaude,Chartreuse
+27,http://fr.dbpedia.org/resource/Col_d'Allos,Col d'Allos,6.59417,44.2972,2247.0,Trois-Évêchés,col,3,Col d'Allos,Trois-Évêchés
+45,http://fr.dbpedia.org/resource/Col_de_Montfuron,Col de Montfuron,5.6975,43.8442,649.0,Luberon,col,3,Col de Montfuron,Luberon
+69,http://fr.dbpedia.org/resource/Col_de_Valante,Col de Valante,7.07,44.68,2815.0,Alpes cottiennes,col,3,Col de Valante,Alpes cottiennes
+134,http://fr.dbpedia.org/resource/Col_de_la_Forclaz_(Haute-Savoie),Col de la Forclaz (Haute-Savoie),6.24472,45.8083,1157.0,Bornes,col,3,Col de la Forclaz,Bornes
+112,http://fr.dbpedia.org/resource/Col_de_la_Vanoise,Col de la Vanoise,6.795,45.3903,2522.0,Vanoise,col,3,Col de la Vanoise,Vanoise
+109,http://fr.dbpedia.org/resource/Col_du_Labouret,Col du Labouret,6.37056,44.2492,1240.0,Trois-Évêchés,col,3,Col du Labouret,Trois-Évêchés
+263,http://fr.dbpedia.org/resource/Corrençon-en-Vercors,Corrençon-en-Vercors,5.52694,45.0322,0.0,0,ski,3,Corrençon-en-Vercors,
+814,http://fr.dbpedia.org/resource/Croix_de_Chamrousse,Croix de Chamrousse,5.90247,45.1258,2253.0,Belledonne,sommet,3,Croix de Chamrousse,Belledonne
+373,http://fr.dbpedia.org/resource/Dôme_du_Goûter,Dôme du Goûter,6.84333,45.8428,4304.0,Mont-Blanc,sommet,3,Dôme du Goûter,Mont-Blanc
+244,http://fr.dbpedia.org/resource/Flumet,Flumet,6.5175,45.8203,0.0,0,ski,3,Flumet,
+197,http://fr.dbpedia.org/resource/Fontcouverte-la-Toussuire,Fontcouverte-la-Toussuire,6.30306,45.2472,1700.0,Arvan-Villards,ski,3,Fontcouverte-la-Toussuire,
+452,http://fr.dbpedia.org/resource/Grand_Pinier,Grand Pinier,6.40139,44.7233,3117.0,Écrins,sommet,3,Grand Pinier,Écrins
+264,http://fr.dbpedia.org/resource/La_Chapelle-d'Abondance,La Chapelle-d'Abondance,6.78806,46.2961,0.0,0,ski,3,La Chapelle-d'Abondance,
+909,0,La Chapelle-en-Valgaudemar,6.204545847763467,44.81906459548416,0.0,0,ville,3,La Chapelle-en-Valgaudemar,
+881,0,La Motte-Servolex,5.878236972339251,45.59954343016685,0.0,0,ville,3,La Motte-Servolex,
+179,http://fr.dbpedia.org/resource/La_Ruchère,La Ruchère,5.79694,45.4092,1165.0,0,ski,3,La Ruchère,
+882,0,Lac d'Aiguebelette,5.79793758689749,45.55178442239692,0.0,0,lac,3,Lac d'Aiguebelette,
+246,http://fr.dbpedia.org/resource/Lans-en-Vercors,Lans-en-Vercors,5.58917,45.1292,0.0,0,ski,3,Lans-en-Vercors,
+887,0,Laragne-Montéglin,5.829195766088718,44.31879082051636,0.0,0,ville,3,Laragne-Montéglin,
+898,0,Larche,6.846105366985783,44.45172243053217,0.0,0,ville,3,Larche,
+291,http://fr.dbpedia.org/resource/Les_Brasses,Les Brasses,6.449,46.168,0.0,0,ski,3,Les Brasses,
+916,0,Les Contamines-Montjoie,6.729091591806778,45.82252717690924,0.0,0,ville,3,Les Contamines-Montjoie,
+202,http://fr.dbpedia.org/resource/Les_Karellis,Les Karellis,6.40331,45.2288,1600.0,Maurienne,ski,3,Les Karellis,
+231,http://fr.dbpedia.org/resource/Manigod,Manigod,6.37056,45.8617,1500.0,0,ski,3,Manigod,
+394,http://fr.dbpedia.org/resource/Mont_Pelat,Mont Pelat,6.70583,44.2647,3050.0,Pelat,sommet,3,Mont Pelat,Pelat
+472,http://fr.dbpedia.org/resource/Montagne_de_Saint-Genis,Montagne de Saint-Genis,5.8375,44.3919,1432.0,Bochaine,sommet,3,Montagne de Saint-Genis,Bochaine
+740,http://fr.dbpedia.org/resource/Montagne_de_la_Lance,Montagne de la Lance,5.10083,44.4575,1338.0,Diois,sommet,3,Montagne de la Lance,Diois
+560,http://fr.dbpedia.org/resource/Moucherotte,Moucherotte,5.63917,45.1478,1901.0,Vercors,sommet,3,Moucherotte,Vercors
+784,http://fr.dbpedia.org/resource/Mourre_Nègre,Mourre Nègre,5.46694,43.8153,1125.0,Luberon,sommet,3,Mourre Nègre,Luberon
+535,http://fr.dbpedia.org/resource/Pic_Coolidge,Pic Coolidge,6.35694,44.9106,3774.0,Écrins,sommet,3,Pic Coolidge,Écrins
+883,0,Pontcharra,6.031241388107246,45.434921905136086,0.0,0,ville,3,Pontcharra,
+911,0,Ristolas,6.954802653304895,44.77482386687705,0.0,0,ville,3,Ristolas,
+232,http://fr.dbpedia.org/resource/Saint-Jean-de-Sixt,Saint-Jean-de-Sixt,6.41056,45.9239,963.0,0,ski,3,Saint-Jean-de-Sixt,
+225,http://fr.dbpedia.org/resource/Saint-Martin-de-Belleville,Saint-Martin-de-Belleville,6.50528,45.3811,1450.0,0,ski,3,Saint-Martin-de-Belleville,
+905,0,Saint-Michel-de-Maurienne,6.47381604416872,45.21834117256122,0.0,0,ville,3,Saint-Michel-de-Maurienne,
+897,0,Saint-Paul-sur-Ubaye,6.751752022298497,44.51546859224411,0.0,0,ville,3,Saint-Paul-sur-Ubaye,
+918,0,Sainte-Foy-Tarentaise,6.884334129135975,45.59180985239221,0.0,0,ville,3,Sainte-Foy-Tarentaise,
+254,http://fr.dbpedia.org/resource/Samoëns,Samoëns,6.72806,46.0847,0.0,0,ski,3,Samoëns,
+903,0,Savines-le-Lac,6.405107455780029,44.52584629850958,0.0,0,ville,3,Savines-le-Lac,
+176,http://fr.dbpedia.org/resource/Semnoz,Semnoz,6.10472,45.7972,1699.0,Bauges,ski,3,Semnoz,Bauges
+340,http://fr.dbpedia.org/resource/Serre_de_l'Aup,Serre de l'Aup,5.24361,44.6608,1195.0,Diois,sommet,3,Serre de l'Aup,Diois
+920,0,Séchilienne,5.844316911130973,45.05730375511637,0.0,0,ville,3,Séchilienne,
+907,0,Ugine,6.424913239080557,45.74812394884372,0.0,0,ville,3,Ugine,
+201,http://fr.dbpedia.org/resource/Valfréjus,Valfréjus,6.65342,45.174,1550.0,Cerces,ski,3,Valfréjus,
+272,http://fr.dbpedia.org/resource/Vallorcine,Vallorcine,6.93389,46.0353,0.0,0,ski,3,Vallorcine,
+203,http://fr.dbpedia.org/resource/Valmorel,Valmorel,6.4425,45.4619,1320.0,Vanoise,ski,3,Valmorel,
+912,0,Abriès,6.92753980037114,44.794623911381606,0.0,0,ville,4,Abriès,
+811,http://fr.dbpedia.org/resource/Aiguille_des_Arias,Aiguille des Arias,6.17167,44.8944,3402.0,Écrins,sommet,4,Aiguille des Arias,Écrins
+255,http://fr.dbpedia.org/resource/Albiez-Montrond,Albiez-Montrond,6.34139,45.2206,0.0,0,ski,4,Albiez-Montrond,
+257,http://fr.dbpedia.org/resource/Allevard,Allevard,6.07472,45.3944,0.0,0,ski,4,Allevard,
+216,http://fr.dbpedia.org/resource/Alpe_du_Grand_Serre,Alpe du Grand Serre,5.86222,45.0239,0.0,Taillefer,ski,4,Alpe du Grand Serre,
+217,http://fr.dbpedia.org/resource/Arêches-Beaufort,Arêches-Beaufort,6.6346,45.4113,0.0,Beaufortain,ski,4,Arêches-Beaufort,
+191,http://fr.dbpedia.org/resource/Auris-en-Oisans_(station),Auris-en-Oisans,6.07806,45.0558,1600.0,Alpes du Nord,ski,4,Auris-en-Oisans,
+196,http://fr.dbpedia.org/resource/Aussois,Aussois,6.74233,45.2272,1500.0,Vanoise,ski,4,Aussois,
+500,http://fr.dbpedia.org/resource/Bec_de_Neurre,Bec de Neurre,5.47333,45.1636,1474.0,Vercors,sommet,4,Bec de Neurre,Vercors
+501,http://fr.dbpedia.org/resource/Bec_de_l'Orient,Bec de l'Orient,5.54722,45.2347,1568.0,Vercors,sommet,4,Bec de l'Orient,Vercors
+194,http://fr.dbpedia.org/resource/Bernex_(Haute-Savoie),Bernex,6.6758,46.3608,900.0,Chablais,ski,4,Bernex,
+250,http://fr.dbpedia.org/resource/Bessans,Bessans,7.0,45.32,0.0,0,ski,4,Bessans,
+259,http://fr.dbpedia.org/resource/Bramans,Bramans,6.77639,45.2244,0.0,0,ski,4,Bramans,
+282,http://fr.dbpedia.org/resource/Brides-les-Bains,Brides-les-Bains,6.5675,45.4533,0.0,0,ski,4,Brides-les-Bains,
+251,http://fr.dbpedia.org/resource/Champagny-en-Vanoise,Champagny-en-Vanoise,6.69333,45.4553,0.0,0,ski,4,Champagny-en-Vanoise,
+516,http://fr.dbpedia.org/resource/Charmant_Som,Charmant Som,5.76417,45.3253,1867.0,Chartreuse,sommet,4,Charmant Som,Chartreuse
+715,http://fr.dbpedia.org/resource/Cheval_Noir,Cheval Noir,6.41361,45.4219,2832.0,Vanoise,sommet,4,Cheval Noir,Vanoise
+229,http://fr.dbpedia.org/resource/Châtel,Châtel,6.84167,46.2675,1183.0,0,ski,4,Châtel,
+387,http://fr.dbpedia.org/resource/Cime_du_Mercantour,Cime du Mercantour,7.29556,44.1439,2772.0,Mercantour,sommet,4,Cime du Mercantour,Mercantour
+174,http://fr.dbpedia.org/resource/Col_d'Ornon,Col d'Ornon,5.96757,45.0088,1367.0,0,col,4,Col d'Ornon,
+144,http://fr.dbpedia.org/resource/Col_de_Bovinant,Col de Bovinant,5.81389,45.3847,1646.0,Chartreuse,col,4,Col de Bovinant,Chartreuse
+77,http://fr.dbpedia.org/resource/Col_de_Fenestre,Col de Fenestre,7.36083,44.1161,2474.0,Mercantour,col,4,Col de Fenestre,Mercantour
+62,http://fr.dbpedia.org/resource/Col_de_l'Échelle,Col de l'Échelle,6.6569,45.0264,1762.0,Cerces,col,4,Col de l'Échelle,Cerces
+70,http://fr.dbpedia.org/resource/Col_de_la_Lombarde,Col de la Lombarde,7.15,44.2028,2351.0,Mercantour,col,4,Col de la Lombarde,Mercantour
+158,http://fr.dbpedia.org/resource/Col_des_Lèques,Col des Lèques,6.46389,43.8656,1146.0,Préalpes de Digne,col,4,Col des Lèques,Préalpes de Digne
+33,http://fr.dbpedia.org/resource/Col_du_Parpaillon,Col du Parpaillon,6.64611,44.4883,2783.0,Parpaillon,col,4,Col du Parpaillon,Parpaillon
+261,http://fr.dbpedia.org/resource/Combloux,Combloux,6.64167,45.8964,0.0,0,ski,4,Combloux,
+262,http://fr.dbpedia.org/resource/Cordon_(Haute-Savoie),Cordon (Haute-Savoie),6.61278,45.9239,0.0,0,ski,4,Cordon,
+283,http://fr.dbpedia.org/resource/Crest-Voland,Crest-Voland,6.50639,45.7958,0.0,0,ski,4,Crest-Voland,
+490,http://fr.dbpedia.org/resource/Dent_de_Moirans,Dent de Moirans,5.59556,45.2875,988.0,Vercors,sommet,4,Dent de Moirans,Vercors
+186,http://fr.dbpedia.org/resource/Désert_d'Entremont,Désert d'Entremont,5.86556,45.4631,1200.0,Chartreuse,ski,4,Désert d'Entremont,
+284,http://fr.dbpedia.org/resource/Hauteluce,Hauteluce,6.58639,45.7519,0.0,0,ski,4,Hauteluce,
+175,http://fr.dbpedia.org/resource/Hirmentaz,Hirmentaz,6.495,46.2297,1607.0,Chablais,ski,4,Hirmentaz,
+234,http://fr.dbpedia.org/resource/La_Chèvrerie_(Haute-Savoie),La Chèvrerie (Haute-Savoie),6.57083,46.2122,1100.0,0,ski,4,La Chèvrerie,
+274,http://fr.dbpedia.org/resource/La_Féclaz,La Féclaz,5.98305,45.6452,0.0,0,ski,4,La Féclaz,
+265,http://fr.dbpedia.org/resource/La_Giettaz,La Giettaz,6.49583,45.8631,0.0,0,ski,4,La Giettaz,
+288,http://fr.dbpedia.org/resource/La_Léchère,La Léchère,6.47417,45.5331,0.0,0,ski,4,La Léchère,
+218,http://fr.dbpedia.org/resource/La_Sambuy-Seythenex,La Sambuy-Seythenex,6.27525,45.7132,1150.0,0,ski,4,La Sambuy-Seythenex,
+242,http://fr.dbpedia.org/resource/La_Tania,La Tania,6.59522,45.4317,1400.0,0,ski,4,La Tania,
+252,http://fr.dbpedia.org/resource/Lanslebourg-Mont-Cenis,Lanslebourg-Mont-Cenis,6.88,45.2864,0.0,0,ski,4,Lanslebourg-Mont-Cenis,
+915,0,Le Monétier-les-Bains,6.509086708829712,44.97685437584322,0.0,0,ville,4,Le Monétier-les-Bains,
+266,http://fr.dbpedia.org/resource/Le_Reposoir,Le Reposoir,6.53583,46.0119,0.0,0,ski,4,Le Reposoir,
+818,http://fr.dbpedia.org/resource/Le_Rochail,Le Rochail,6.03111,44.98,3022.0,Écrins,sommet,4,Le Rochail,Écrins
+528,http://fr.dbpedia.org/resource/Le_Sirac,Le Sirac,6.30667,44.7889,3441.0,Écrins,sommet,4,Le Sirac,Écrins
+205,http://fr.dbpedia.org/resource/Les_Aillons-Margériaz,Les Aillons-Margériaz,6.06231,45.6429,1000.0,Bauges,ski,4,Les Aillons-Margériaz,
+267,http://fr.dbpedia.org/resource/Les_Gets,Les Gets,6.67083,46.1606,0.0,0,ski,4,Les Gets,
+185,http://fr.dbpedia.org/resource/Les_Saisies,Les Saisies,6.54178,45.7564,990.0,Beaufortain,ski,4,Les Saisies,
+279,http://fr.dbpedia.org/resource/Linga_-_Pré_La_Joux,Linga - Pré La Joux,6.83833,46.2814,0.0,0,ski,4,Linga - Pré La Joux,
+738,http://fr.dbpedia.org/resource/Mont_Ténibre,Mont Ténibre,6.97139,44.2839,3031.0,Mercantour,sommet,4,Mont Ténibre,Mercantour
+268,http://fr.dbpedia.org/resource/Mont-Saxonnex,Mont-Saxonnex,6.485,46.0547,0.0,0,ski,4,Mont-Saxonnex,
+410,http://fr.dbpedia.org/resource/Montagne_de_Chabre,Montagne de Chabre,5.64278,44.2658,1393.0,Baronnies,sommet,4,Montagne de Chabre,Baronnies
+275,http://fr.dbpedia.org/resource/Morillon_(Haute-Savoie),Morillon,6.6775,46.0833,0.0,0,ski,4,Morillon,
+210,http://fr.dbpedia.org/resource/Méaudre,Méaudre,5.52778,45.1278,0.0,Vercors,ski,4,Méaudre,
+285,http://fr.dbpedia.org/resource/Notre-Dame-de-Bellecombe,Notre-Dame-de-Bellecombe,6.51972,45.8103,0.0,0,ski,4,Notre-Dame-de-Bellecombe,
+199,http://fr.dbpedia.org/resource/Orelle,Orelle,6.53778,45.21,890.0,Vanoise,ski,4,Orelle,
+247,http://fr.dbpedia.org/resource/Oz_(Isère),Oz (Isère),6.0511,45.1406,0.0,0,ski,4,Oz,
+243,http://fr.dbpedia.org/resource/Passy_Plaine-Joux,Passy Plaine-Joux,6.74015,45.9508,1360.0,0,ski,4,Passy Plaine-Joux,
+248,http://fr.dbpedia.org/resource/Peisey-Nancroix,Peisey-Nancroix,6.75694,45.5472,0.0,0,ski,4,Peisey-Nancroix,
+195,http://fr.dbpedia.org/resource/Peisey-Vallandry,Peisey-Vallandry,6.75694,45.5472,1600.0,Vanoise,ski,4,Peisey-Vallandry,
+383,http://fr.dbpedia.org/resource/Pic_de_Bure,Pic de Bure,5.935,44.6269,2709.0,Dévoluy,sommet,4,Pic de Bure,Dévoluy
+538,http://fr.dbpedia.org/resource/Pic_de_la_Grave,Pic de la Grave,6.24944,44.9964,3667.0,Écrins,sommet,4,Pic de la Grave,Écrins
+405,http://fr.dbpedia.org/resource/Pierra_Menta,Pierra Menta,6.65083,45.6381,2714.0,Beaufortain,sommet,4,Pierra Menta,Beaufortain
+848,http://fr.dbpedia.org/resource/Pointe_des_Estaris,Pointe des Estaris,6.34167,44.7425,3086.0,Écrins,sommet,4,Pointe des Estaris,Écrins
+286,http://fr.dbpedia.org/resource/Pralognan-la-Vanoise,Pralognan-la-Vanoise,6.72222,45.3825,0.0,0,ski,4,Pralognan-la-Vanoise,
+206,http://fr.dbpedia.org/resource/Praz_de_Lys_-_Sommand,Praz de Lys - Sommand,6.5906,46.147,1500.0,Chablais,ski,4,Praz de Lys - Sommand,
+269,http://fr.dbpedia.org/resource/Praz-sur-Arly,Praz-sur-Arly,6.57083,45.8381,0.0,0,ski,4,Praz-sur-Arly,
+543,http://fr.dbpedia.org/resource/Roche_de_la_Muzelle,Roche de la Muzelle,6.10528,44.9311,3465.0,Écrins,sommet,4,Roche de la Muzelle,Écrins
+902,0,Réallon,6.364278587164024,44.59582343991221,0.0,0,ville,4,Réallon,
+200,http://fr.dbpedia.org/resource/Saint-Colomban-des-Villards,Saint-Colomban-des-Villards,6.22722,45.295,1100.0,Belledonne,ski,4,Saint-Colomban-des-Villards,
+237,http://fr.dbpedia.org/resource/Saint-François-Longchamp,Saint-François-Longchamp,6.34917,45.4106,1650.0,0,ski,4,Saint-François-Longchamp,
+249,http://fr.dbpedia.org/resource/Saint-Hilaire_(Isère),Saint-Hilaire (Isère),5.8875,45.3108,0.0,0,ski,4,Saint-Hilaire,
+238,http://fr.dbpedia.org/resource/Saint-Jean-d'Arves,Saint-Jean-d'Arves,6.27389,45.2081,1550.0,0,ski,4,Saint-Jean-d'Arves,
+239,http://fr.dbpedia.org/resource/Saint-Sorlin-d'Arves,Saint-Sorlin-d'Arves,6.23083,45.2205,1550.0,0,ski,4,Saint-Sorlin-d'Arves,
+240,http://fr.dbpedia.org/resource/Sainte-Foy-Tarentaise,Sainte-Foy-Tarentaise,6.88444,45.59,813.0,0,ski,4,Sainte-Foy-Tarentaise,
+241,http://fr.dbpedia.org/resource/Savoie_Grand_Revard,Savoie Grand Revard,5.97824,45.682,1350.0,0,ski,4,Savoie Grand Revard,
+459,http://fr.dbpedia.org/resource/Signal_de_Saint-Pierre,Signal de Saint-Pierre,5.48528,43.9794,1256.0,Monts de Vaucluse,sommet,4,Signal de Saint-Pierre,Monts de Vaucluse
+270,http://fr.dbpedia.org/resource/Sixt-Fer-à-Cheval,Sixt-Fer-à-Cheval,6.77639,46.0558,0.0,0,ski,4,Sixt-Fer-à-Cheval,
+271,http://fr.dbpedia.org/resource/Thollon-les-Mémises,Thollon-les-Mémises,6.69972,46.3889,0.0,0,ski,4,Thollon-les-Mémises,
+287,http://fr.dbpedia.org/resource/Valmeinier,Valmeinier,6.48194,45.1847,0.0,0,ski,4,Valmeinier,
+273,http://fr.dbpedia.org/resource/Verchaix,Verchaix,6.67694,46.0972,0.0,0,ski,4,Verchaix,
+757,http://fr.dbpedia.org/resource/Aiguille_Croche,Aiguille Croche,6.65917,45.8003,2487.0,Beaufortain,sommet,5,Aiguille Croche,Beaufortain
+514,http://fr.dbpedia.org/resource/Aiguille_Dibona,Aiguille Dibona,6.24278,44.9625,3131.0,Écrins,sommet,5,Aiguille Dibona,Écrins
+396,http://fr.dbpedia.org/resource/Aiguille_Rouge,Aiguille Rouge,6.84861,45.5519,3227.0,Vanoise,sommet,5,Aiguille Rouge,Vanoise
+438,http://fr.dbpedia.org/resource/Aiguille_Verte,Aiguille Verte,6.97,45.9347,4122.0,Mont-Blanc,sommet,5,Aiguille Verte,Mont-Blanc
+728,http://fr.dbpedia.org/resource/Aiguille_d'Argentière,Aiguille d'Argentière,7.02028,45.9597,3902.0,Mont-Blanc,sommet,5,Aiguille d'Argentière,Mont-Blanc
+805,http://fr.dbpedia.org/resource/Aiguille_de_Blaitière,Aiguille de Blaitière,6.91306,45.8992,3522.0,Aiguilles de Chamonix,sommet,5,Aiguille de Blaitière,Aiguilles de Chamonix
+659,http://fr.dbpedia.org/resource/Aiguille_de_Borderan,Aiguille de Borderan,6.47778,45.8864,2492.0,Aravis,sommet,5,Aiguille de Borderan,Aravis
+480,http://fr.dbpedia.org/resource/Aiguille_de_Chalais,Aiguille de Chalais,5.66056,45.2939,1089.0,Chartreuse,sommet,5,Aiguille de Chalais,Chartreuse
+397,http://fr.dbpedia.org/resource/Aiguille_de_Chambeyron,Aiguille de Chambeyron,6.85611,44.5472,3412.0,Chambeyron,sommet,5,Aiguille de Chambeyron,Chambeyron
+425,http://fr.dbpedia.org/resource/Aiguille_de_Criou,Aiguille de Criou,6.76361,46.0953,2207.0,Giffre,sommet,5,Aiguille de Criou,Giffre
+840,http://fr.dbpedia.org/resource/Aiguille_de_Leschaux,Aiguille de Leschaux,7.00667,45.8872,3759.0,Mont-Blanc,sommet,5,Aiguille de Leschaux,Mont-Blanc
+758,http://fr.dbpedia.org/resource/Aiguille_de_Polset,Aiguille de Polset,6.63917,45.2764,3531.0,Vanoise,sommet,5,Aiguille de Polset,Vanoise
+759,http://fr.dbpedia.org/resource/Aiguille_de_Péclet,Aiguille de Péclet,6.62389,45.2811,3561.0,Vanoise,sommet,5,Aiguille de Péclet,Vanoise
+660,http://fr.dbpedia.org/resource/Aiguille_de_Quaix,Aiguille de Quaix,5.72,45.2669,1143.0,Chartreuse,sommet,5,Aiguille de Quaix,Chartreuse
+420,http://fr.dbpedia.org/resource/Aiguille_de_Roc,Aiguille de Roc,6.91889,45.9014,3409.0,Aiguilles de Chamonix,sommet,5,Aiguille de Roc,Aiguilles de Chamonix
+810,http://fr.dbpedia.org/resource/Aiguille_de_Rochefort,Aiguille de Rochefort,6.96,45.8619,4001.0,Mont-Blanc,sommet,5,Aiguille de Rochefort,Mont-Blanc
+481,http://fr.dbpedia.org/resource/Aiguille_de_Scolette,Aiguille de Scolette,6.76806,45.1597,3506.0,Mont-Cenis,sommet,5,Aiguille de Scolette,Mont-Cenis
+841,http://fr.dbpedia.org/resource/Aiguille_de_Talèfre,Aiguille de Talèfre,7.00389,45.8997,3730.0,Mont-Blanc,sommet,5,Aiguille de Talèfre,Mont-Blanc
+343,http://fr.dbpedia.org/resource/Aiguille_de_Triolet,Aiguille de Triolet,7.02444,45.9164,3870.0,Mont-Blanc,sommet,5,Aiguille de Triolet,Mont-Blanc
+863,http://fr.dbpedia.org/resource/Aiguille_de_Varan,Aiguille de Varan,6.68278,45.9583,2544.0,0,sommet,5,Aiguille de Varan,
+349,http://fr.dbpedia.org/resource/Aiguille_de_l'A_Neuve,Aiguille de l'A Neuve,7.03667,45.9522,3753.0,Mont-Blanc,sommet,5,Aiguille de l'A Neuve,Mont-Blanc
+842,http://fr.dbpedia.org/resource/Aiguille_de_la_Floria,Aiguille de la Floria,6.86861,45.9761,2888.0,Aiguilles Rouges,sommet,5,Aiguille de la Floria,Aiguilles Rouges
+710,http://fr.dbpedia.org/resource/Aiguille_de_la_Grande_Sassière,Aiguille de la Grande Sassière,6.99972,45.5047,3747.0,Alpes grées,sommet,5,Aiguille de la Grande Sassière,Alpes grées
+421,http://fr.dbpedia.org/resource/Aiguille_de_la_République,Aiguille de la République,6.92139,45.9056,3305.0,Aiguilles de Chamonix,sommet,5,Aiguille de la République,Aiguilles de Chamonix
+729,http://fr.dbpedia.org/resource/Aiguille_de_la_Vanoise,Aiguille de la Vanoise,6.77917,45.3947,2796.0,Vanoise,sommet,5,Aiguille de la Vanoise,Vanoise
+344,http://fr.dbpedia.org/resource/Aiguille_des_Glaciers,Aiguille des Glaciers,6.8025,45.7786,3816.0,Mont-Blanc,sommet,5,Aiguille des Glaciers,Mont-Blanc
+292,http://fr.dbpedia.org/resource/Aiguille_des_Grands_Charmoz,Aiguille des Grands Charmoz,6.91889,45.9044,3445.0,Aiguilles de Chamonix,sommet,5,Aiguille des Grands Charmoz,Aiguilles de Chamonix
+293,http://fr.dbpedia.org/resource/Aiguille_des_Grands_Montets,Aiguille des Grands Montets,6.96056,45.9481,3295.0,Mont-Blanc,sommet,5,Aiguille des Grands Montets,Mont-Blanc
+422,http://fr.dbpedia.org/resource/Aiguille_des_Pélerins,Aiguille des Pélerins,6.90167,45.895,3318.0,Aiguilles de Chamonix,sommet,5,Aiguille des Pélerins,Aiguilles de Chamonix
+294,http://fr.dbpedia.org/resource/Aiguille_du_Belvédère,Aiguille du Belvédère,6.87333,45.9875,2965.0,Aiguilles Rouges,sommet,5,Aiguille du Belvédère,Aiguilles Rouges
+416,http://fr.dbpedia.org/resource/Aiguille_du_Chardonnet,Aiguille du Chardonnet,7.00139,45.9689,3824.0,Mont-Blanc,sommet,5,Aiguille du Chardonnet,Mont-Blanc
+760,http://fr.dbpedia.org/resource/Aiguille_du_Fou,Aiguille du Fou,6.91194,45.8972,3501.0,Aiguilles de Chamonix,sommet,5,Aiguille du Fou,Aiguilles de Chamonix
+702,http://fr.dbpedia.org/resource/Aiguille_du_Fruit,Aiguille du Fruit,6.63111,45.3556,3048.0,Vanoise,sommet,5,Aiguille du Fruit,Vanoise
+661,http://fr.dbpedia.org/resource/Aiguille_du_Goûter,Aiguille du Goûter,6.83111,45.8506,3863.0,Mont-Blanc,sommet,5,Aiguille du Goûter,Mont-Blanc
+761,http://fr.dbpedia.org/resource/Aiguille_du_Grand_Fond,Aiguille du Grand Fond,6.67083,45.6661,2920.0,Beaufortain,sommet,5,Aiguille du Grand Fond,Beaufortain
+806,http://fr.dbpedia.org/resource/Aiguille_du_Grépon,Aiguille du Grépon,6.91917,45.9025,3482.0,Aiguilles de Chamonix,sommet,5,Aiguille du Grépon,Aiguilles de Chamonix
+812,http://fr.dbpedia.org/resource/Aiguille_du_Jardin,Aiguille du Jardin,6.97583,45.9339,4035.0,Mont-Blanc,sommet,5,Aiguille du Jardin,Mont-Blanc
+703,http://fr.dbpedia.org/resource/Aiguille_du_Moine,Aiguille du Moine,6.96139,45.9167,3412.0,Mont-Blanc,sommet,5,Aiguille du Moine,Mont-Blanc
+688,http://fr.dbpedia.org/resource/Aiguille_du_Peigne,Aiguille du Peigne,6.89944,45.8958,3192.0,Aiguilles de Chamonix,sommet,5,Aiguille du Peigne,Aiguilles de Chamonix
+807,http://fr.dbpedia.org/resource/Aiguille_du_Plan,Aiguille du Plan,6.90722,45.8917,3673.0,Aiguilles de Chamonix,sommet,5,Aiguille du Plan,Aiguilles de Chamonix
+515,http://fr.dbpedia.org/resource/Aiguille_du_Plat_de_la_Selle,Aiguille du Plat de la Selle,6.22222,44.9636,3596.0,Écrins,sommet,5,Aiguille du Plat de la Selle,Écrins
+362,http://fr.dbpedia.org/resource/Aiguille_du_Tacul,Aiguille du Tacul,6.96111,45.8847,3444.0,Mont-Blanc,sommet,5,Aiguille du Tacul,Mont-Blanc
+345,http://fr.dbpedia.org/resource/Aiguille_du_Tour,Aiguille du Tour,7.00944,45.9942,3542.0,Mont-Blanc,sommet,5,Aiguille du Tour,Mont-Blanc
+363,http://fr.dbpedia.org/resource/Aiguilles_de_Pelens,Aiguilles de Pelens,6.71639,44.1425,2523.0,Pelat,sommet,5,Aiguilles de Pelens,Pelat
+762,http://fr.dbpedia.org/resource/Aiguilles_de_la_Penaz,Aiguilles de la Penaz,6.69944,45.7447,2688.0,Beaufortain,sommet,5,Aiguilles de la Penaz,Beaufortain
+346,http://fr.dbpedia.org/resource/Aiguillette_du_Lauzet,Aiguillette du Lauzet,6.48333,45.0214,2717.0,Cerces,sommet,5,Aiguillette du Lauzet,Cerces
+708,http://fr.dbpedia.org/resource/Albaron_(sommet),Albaron,7.10111,45.3339,3638.0,Alpes grées,sommet,5,Albaron,Alpes grées
+451,http://fr.dbpedia.org/resource/Arcalod,Arcalod,6.22833,45.6819,2217.0,Bauges,sommet,5,Arcalod,Bauges
+547,http://fr.dbpedia.org/resource/Arêtes_du_Gerbier,Arêtes du Gerbier,5.58917,45.0253,2109.0,Vercors,sommet,5,Arêtes du Gerbier,Vercors
+177,http://fr.dbpedia.org/resource/Auris,Auris,6.0875,45.0472,1240.0,0,ski,5,Auris,
+327,http://fr.dbpedia.org/resource/Baou_de_Saint-Jeannet,Baou de Saint-Jeannet,7.13806,43.7506,802.0,Préalpes de Grasse,sommet,5,Baou de Saint-Jeannet,Préalpes de Grasse
+849,http://fr.dbpedia.org/resource/Baou_des_Blancs,Baou des Blancs,7.10903,43.7341,673.0,Préalpes de Castellane,sommet,5,Baou des Blancs,Préalpes de Castellane
+850,http://fr.dbpedia.org/resource/Baou_des_Noirs,Baou des Noirs,7.12389,43.7431,678.0,Préalpes de Castellane,sommet,5,Baou des Noirs,Préalpes de Castellane
+376,http://fr.dbpedia.org/resource/Barre_des_Écrins,Barre des Écrins,6.35944,44.9219,4102.0,Écrins,sommet,5,Barre des Écrins,Écrins
+725,http://fr.dbpedia.org/resource/Bauroux,Bauroux,6.71778,43.7811,1644.0,Préalpes de Castellane,sommet,5,Bauroux,Préalpes de Castellane
+350,http://fr.dbpedia.org/resource/Bec_Charvet,Bec Charvet,5.82861,45.2964,1738.0,Chartreuse,sommet,5,Bec Charvet,Chartreuse
+502,http://fr.dbpedia.org/resource/Bec_de_l'Échaillon,Bec de l'Échaillon,5.6025,45.2983,622.0,Vercors,sommet,5,Bec de l'Échaillon,Vercors
+398,http://fr.dbpedia.org/resource/Bellecôte,Bellecôte,6.78222,45.4928,3417.0,Vanoise,sommet,5,Bellecôte,Vanoise
+709,http://fr.dbpedia.org/resource/Bessanèse,Bessanèse,7.11667,45.3,3592.0,Alpes grées,sommet,5,Bessanèse,Alpes grées
+482,http://fr.dbpedia.org/resource/Blayeul,Blayeul,6.31167,44.2469,2189.0,Trois-Évêchés,sommet,5,Blayeul,Trois-Évêchés
+399,http://fr.dbpedia.org/resource/Brec_de_Chambeyron,Brec de Chambeyron,6.85278,44.5269,3389.0,Chambeyron,sommet,5,Brec de Chambeyron,Chambeyron
+469,http://fr.dbpedia.org/resource/Bric_Froid,Bric Froid,6.93139,44.8636,3302.0,Alpes cottiennes,sommet,5,Bric Froid,Alpes cottiennes
+306,http://fr.dbpedia.org/resource/Bric_de_Rubren,Bric de Rubren,6.94972,44.6197,3340.0,Chambeyron,sommet,5,Bric de Rubren,Chambeyron
+385,http://fr.dbpedia.org/resource/Caïres_de_Cougourde,Caïres de Cougourde,7.34583,44.1364,2921.0,Mercantour,sommet,5,Caïres de Cougourde,Mercantour
+295,http://fr.dbpedia.org/resource/Chapeau_de_Gendarme_(montagne),Chapeau de Gendarme,6.665,44.3372,2682.0,Mercantour,sommet,5,Chapeau de Gendarme,Mercantour
+730,http://fr.dbpedia.org/resource/Château_d'Oche_(montagne),Château d'Oche,6.74306,46.35,2197.0,Chablais,sommet,5,Château d'Oche,Chablais
+695,http://fr.dbpedia.org/resource/Cime_Gardoria,Cime Gardoria,6.73611,45.1383,3137.0,Mont-Cenis,sommet,5,Cime Gardoria,Mont-Cenis
+412,http://fr.dbpedia.org/resource/Cime_Guilié,Cime Guilié,7.31056,44.1475,2999.0,Mercantour,sommet,5,Cime Guilié,Mercantour
+689,http://fr.dbpedia.org/resource/Cime_de_Baissette,Cime de Baissette,7.31083,44.1364,2822.0,Mercantour,sommet,5,Cime de Baissette,Mercantour
+460,http://fr.dbpedia.org/resource/Cime_de_Caron,Cime de Caron,6.56167,45.2631,3195.0,Vanoise,sommet,5,Cime de Caron,Vanoise
+364,http://fr.dbpedia.org/resource/Cime_de_Frémamorte,Cime de Frémamorte,7.25056,44.1569,2730.0,Mercantour,sommet,5,Cime de Frémamorte,Mercantour
+432,http://fr.dbpedia.org/resource/Cime_de_Peïra-Cava,Cime de Peïra-Cava,7.37,43.9394,1581.0,Préalpes de Nice,sommet,5,Cime de Peïra-Cava,Préalpes de Nice
+461,http://fr.dbpedia.org/resource/Cime_de_Sistron,Cime de Sistron,7.1242,44.173,2603.0,Mercantour,sommet,5,Cime de Sistron,Mercantour
+517,http://fr.dbpedia.org/resource/Cime_de_l'Encoula,Cime de l'Encoula,6.28333,44.905,3536.0,Écrins,sommet,5,Cime de l'Encoula,Écrins
+372,http://fr.dbpedia.org/resource/Cime_de_la_Bonette,Cime de la Bonette,6.80694,44.3217,2860.0,Mercantour,sommet,5,Cime de la Bonette,Mercantour
+307,http://fr.dbpedia.org/resource/Cime_de_la_Lombarde,Cime de la Lombarde,7.16306,44.2083,2800.0,Mercantour,sommet,5,Cime de la Lombarde,Mercantour
+763,http://fr.dbpedia.org/resource/Cime_de_la_Malédie,Cime de la Malédie,7.39833,44.1222,3059.0,Mercantour,sommet,5,Cime de la Malédie,Mercantour
+386,http://fr.dbpedia.org/resource/Cime_du_Diable,Cime du Diable,7.42333,44.0492,2685.0,Mercantour,sommet,5,Cime du Diable,Mercantour
+696,http://fr.dbpedia.org/resource/Cime_du_Grand_Vallon,Cime du Grand Vallon,6.71167,45.1447,3129.0,Mont-Cenis,sommet,5,Cime du Grand Vallon,Mont-Cenis
+508,http://fr.dbpedia.org/resource/Cime_du_Gélas,Cime du Gélas,7.38389,44.1228,3143.0,Mercantour,sommet,5,Cime du Gélas,Mercantour
+308,http://fr.dbpedia.org/resource/Cimet,Cimet,6.70417,44.2906,3020.0,Pelat,sommet,5,Cimet,Pelat
+20,http://fr.dbpedia.org/resource/Col_Agnel,Col Agnel,6.9794,44.6842,2744.0,Escreins,col,5,Col Agnel,Escreins
+97,http://fr.dbpedia.org/resource/Col_Bayard,Col Bayard,6.08134,44.6128,1248.0,Écrins,col,5,Col Bayard,Écrins
+12,http://fr.dbpedia.org/resource/Col_Clapier,Col Clapier,6.92278,45.1669,2477.0,Mont-Cenis,col,5,Col Clapier,Mont-Cenis
+2,http://fr.dbpedia.org/resource/Col_Infranchissable,Col Infranchissable,6.80833,45.8125,3349.0,Mont-Blanc,col,5,Col Infranchissable,Mont-Blanc
+169,http://fr.dbpedia.org/resource/Col_Lacroix,Col Lacroix,7.02328,44.7645,2298.0,Alpes cottiennes,col,5,Col Lacroix,Alpes cottiennes
+136,http://fr.dbpedia.org/resource/Col_Luitel,Col Luitel,5.84889,45.0875,1262.0,Belledonne,col,5,Col Luitel,Belledonne
+87,http://fr.dbpedia.org/resource/Col_Saint-Martin,Col Saint-Martin,7.22139,44.0708,1503.0,Mercantour,col,5,Col Saint-Martin,Mercantour
+149,http://fr.dbpedia.org/resource/Col_Saint-Roch,Col Saint-Roch,7.33833,43.8958,991.0,Préalpes de Nice,col,5,Col Saint-Roch,Préalpes de Nice
+84,http://fr.dbpedia.org/resource/Col_d'Ambin,Col d'Ambin,6.88,45.1347,2899.0,Mont-Cenis,col,5,Col d'Ambin,Mont-Cenis
+24,http://fr.dbpedia.org/resource/Col_d'Anterne,Col d'Anterne,6.79639,45.9803,2257.0,Giffre,col,5,Col d'Anterne,Giffre
+53,http://fr.dbpedia.org/resource/Col_d'Ey,Col d'Ey,5.27778,44.3128,718.0,Baronnies,col,5,Col d'Ey,Baronnies
+80,http://fr.dbpedia.org/resource/Col_d'Urine,Col d'Urine,7.00444,44.7939,2525.0,Alpes cottiennes,col,5,Col d'Urine,Alpes cottiennes
+26,http://fr.dbpedia.org/resource/Col_d'Èze,Col d'Èze,7.34667,43.7339,507.0,Préalpes de Nice,col,5,Col d'Èze,Préalpes de Nice
+75,http://fr.dbpedia.org/resource/Col_de_Balme,Col de Balme,6.96944,46.0272,2191.0,Mont-Blanc,col,5,Col de Balme,Mont-Blanc
+147,http://fr.dbpedia.org/resource/Col_de_Bassachaux,Col de Bassachaux,6.77222,46.2222,1778.0,Chablais,col,5,Col de Bassachaux,Chablais
+13,http://fr.dbpedia.org/resource/Col_de_Bornette,Col de Bornette,6.18528,45.7328,1304.0,Bauges,col,5,Col de Bornette,Bauges
+88,http://fr.dbpedia.org/resource/Col_de_Braus,Col de Braus,7.39889,43.8728,1002.0,Préalpes de Nice,col,5,Col de Braus,Préalpes de Nice
+155,http://fr.dbpedia.org/resource/Col_de_Bretolet,Col de Bretolet,6.79611,46.1425,1936.0,Chablais,col,5,Col de Bretolet,Chablais
+150,http://fr.dbpedia.org/resource/Col_de_Cabre_(Alpes),Col de Cabre,5.59833,44.5494,1180.0,Diois,col,5,Col de Cabre,Diois
+159,http://fr.dbpedia.org/resource/Col_de_Carri,Col de Carri,5.3625,44.9442,1202.0,Vercors,col,5,Col de Carri,Vercors
+89,http://fr.dbpedia.org/resource/Col_de_Castillon,Col de Castillon,7.46083,43.8392,728.0,Préalpes de Nice,col,5,Col de Castillon,Préalpes de Nice
+76,http://fr.dbpedia.org/resource/Col_de_Cerise,Col de Cerise,7.28417,44.1417,2543.0,Mercantour,col,5,Col de Cerise,Mercantour
+151,http://fr.dbpedia.org/resource/Col_de_Chavan,Col de Chavan,6.55944,46.1772,1745.0,Chablais,col,5,Col de Chavan,Chablais
+114,http://fr.dbpedia.org/resource/Col_de_Chavière,Col de Chavière,6.65722,45.2706,2796.0,Vanoise,col,5,Col de Chavière,Vanoise
+152,http://fr.dbpedia.org/resource/Col_de_Châteauneuf_de_Contes,Col de Châteauneuf de Contes,7.29306,43.8003,627.0,Préalpes de Nice,col,5,Col de Châteauneuf de Contes,Préalpes de Nice
+125,http://fr.dbpedia.org/resource/Col_de_Clavel,Col de Clavel,6.63,43.7497,1069.0,Préalpes de Castellane,col,5,Col de Clavel,Préalpes de Castellane
+43,http://fr.dbpedia.org/resource/Col_de_Corobin,Col de Corobin,6.32024,44.0079,1230.0,Trois-Évêchés,col,5,Col de Corobin,Trois-Évêchés
+37,http://fr.dbpedia.org/resource/Col_de_Cou_(Vallée_Verte),Col de Cou (Vallée Verte),6.45444,46.2622,1117.0,Chablais,col,5,Col de Cou,Chablais
+90,http://fr.dbpedia.org/resource/Col_de_Cou_(Barme),Col de Cou (Barme),6.79306,46.15,1921.0,Chablais,col,5,Col de Cou,Chablais
+171,http://fr.dbpedia.org/resource/Col_de_Couz,Col de Couz,5.81722,45.4692,624.0,0,col,5,Col de Couz,
+122,http://fr.dbpedia.org/resource/Col_de_Font-Belle,Col de Font-Belle,6.14722,44.2153,1304.0,Préalpes de Digne,col,5,Col de Font-Belle,Préalpes de Digne
+38,http://fr.dbpedia.org/resource/Col_de_Foron,Col de Foron,6.59,46.1811,1832.0,Chablais,col,5,Col de Foron,Chablais
+4,http://fr.dbpedia.org/resource/Col_de_Freissinières,Col de Freissinières,6.35361,44.7375,2782.0,Écrins,col,5,Col de Freissinières,Écrins
+1,http://fr.dbpedia.org/resource/Col_de_Gleize,Col de Gleize,6.04806,44.6222,1696.0,Dévoluy,col,5,Col de Gleize,Dévoluy
+58,http://fr.dbpedia.org/resource/Col_de_Granon,Col de Granon,6.61111,44.9628,2413.0,Cerces,col,5,Col de Granon,Cerces
+98,http://fr.dbpedia.org/resource/Col_de_Grimone,Col de Grimone,5.65397,44.6917,1318.0,Diois,col,5,Col de Grimone,Diois
+0,http://fr.dbpedia.org/resource/Col_de_Jambaz,Col de Jambaz,6.52028,46.2347,1027.0,Chablais,col,5,Col de Jambaz,Chablais
+18,http://fr.dbpedia.org/resource/Col_de_Leschaux,Col de Leschaux,6.13167,45.7719,897.0,Bauges,col,5,Col de Leschaux,Bauges
+44,http://fr.dbpedia.org/resource/Col_de_Luens,Col de Luens,6.5873,43.8186,1054.0,Préalpes de Castellane,col,5,Col de Luens,Préalpes de Castellane
+145,http://fr.dbpedia.org/resource/Col_de_Léchaud,Col de Léchaud,5.80889,45.3872,1704.0,Chartreuse,col,5,Col de Léchaud,Chartreuse
+137,http://fr.dbpedia.org/resource/Col_de_Macuègne,Col de Macuègne,5.51,44.1819,1068.0,Monts de Vaucluse,col,5,Col de Macuègne,Monts de Vaucluse
+60,http://fr.dbpedia.org/resource/Col_de_Manse,Col de Manse,6.13176,44.6115,1269.0,Écrins,col,5,Col de Manse,Écrins
+119,http://fr.dbpedia.org/resource/Col_de_Marcieu,Col de Marcieu,5.91879,45.3559,1065.0,Chartreuse,col,5,Col de Marcieu,Chartreuse
+91,http://fr.dbpedia.org/resource/Col_de_Mary,Col de Mary,6.88639,44.5522,2641.0,Chambeyron,col,5,Col de Mary,Chambeyron
+5,http://fr.dbpedia.org/resource/Col_de_Mens,Col de Mens,5.77167,44.7603,1111.0,Dévoluy,col,5,Col de Mens,Dévoluy
+6,http://fr.dbpedia.org/resource/Col_de_Menée,Col de Menée,5.60361,44.7578,1457.0,Diois,col,5,Col de Menée,Diois
+3,http://fr.dbpedia.org/resource/Col_de_Miage,Col de Miage,6.81111,45.8244,3367.0,Mont-Blanc,col,5,Col de Miage,Mont-Blanc
+36,http://fr.dbpedia.org/resource/Col_de_Moissière,Col de Moissière,6.2204,44.6014,1571.0,Écrins,col,5,Col de Moissière,Écrins
+66,http://fr.dbpedia.org/resource/Col_de_Murs,Col de Murs,5.22639,43.9767,627.0,Monts de Vaucluse,col,5,Col de Murs,Monts de Vaucluse
+7,http://fr.dbpedia.org/resource/Col_de_Palaquit,Col de Palaquit,5.76556,45.2728,1154.0,Chartreuse,col,5,Col de Palaquit,Chartreuse
+120,http://fr.dbpedia.org/resource/Col_de_Pelouse,Col de Pelouse,6.74861,45.1422,2793.0,Mont-Cenis,col,5,Col de Pelouse,Mont-Cenis
+126,http://fr.dbpedia.org/resource/Col_de_Pennes,Col de Pennes,5.3425,44.6447,1040.0,Diois,col,5,Col de Pennes,Diois
+94,http://fr.dbpedia.org/resource/Col_de_Porte_(Isère),Col de Porte,5.76722,45.2894,1326.0,Chartreuse,col,5,Col de Porte,Chartreuse
+160,http://fr.dbpedia.org/resource/Col_de_Proncel,Col de Proncel,5.38194,44.9281,1100.0,Vercors,col,5,Col de Proncel,Vercors
+141,http://fr.dbpedia.org/resource/Col_de_Rabou,Col de Rabou,5.98139,44.6417,1888.0,Dévoluy,col,5,Col de Rabou,Dévoluy
+67,http://fr.dbpedia.org/resource/Col_de_Restefond,Col de Restefond,6.80861,44.3364,2680.0,Mercantour,col,5,Col de Restefond,Mercantour
+161,http://fr.dbpedia.org/resource/Col_de_Romeyère,Col de Romeyère,5.47972,45.1436,1069.0,Vercors,col,5,Col de Romeyère,Vercors
+81,http://fr.dbpedia.org/resource/Col_de_Romme,Col de Romme,6.57389,46.03,1297.0,Aravis,col,5,Col de Romme,Aravis
+162,http://fr.dbpedia.org/resource/Col_de_Saint-Alexis,Col de Saint-Alexis,5.40722,44.8722,1222.0,Vercors,col,5,Col de Saint-Alexis,Vercors
+123,http://fr.dbpedia.org/resource/Col_de_Sarenne,Col de Sarenne,6.14917,45.0874,1999.0,Grandes Rousses,col,5,Col de Sarenne,Grandes Rousses
+131,http://fr.dbpedia.org/resource/Col_de_Tamié,Col de Tamié,6.30861,45.6728,907.0,Bauges,col,5,Col de Tamié,Bauges
+39,http://fr.dbpedia.org/resource/Col_de_Terramont,Col de Terramont,6.49056,46.2469,1096.0,Chablais,col,5,Col de Terramont,Chablais
+163,http://fr.dbpedia.org/resource/Col_de_Tourniol,Col de Tourniol,5.18444,44.9189,1145.0,Vercors,col,5,Col de Tourniol,Vercors
+40,http://fr.dbpedia.org/resource/Col_de_Vence_(Isère),Col de Vence (Isère),5.75083,45.2358,782.0,Chartreuse,col,5,Col de Vence,Chartreuse
+153,http://fr.dbpedia.org/resource/Col_de_Vésinaz,Col de Vésinaz,6.575,46.1758,1802.0,Chablais,col,5,Col de Vésinaz,Chablais
+164,http://fr.dbpedia.org/resource/Col_de_l'Allimas,Col de l'Allimas,5.56694,44.8819,1352.0,Vercors,col,5,Col de l'Allimas,Vercors
+127,http://fr.dbpedia.org/resource/Col_de_l'Alpe,Col de l'Alpe,5.92806,45.4169,1793.0,Chartreuse,col,5,Col de l'Alpe,Chartreuse
+128,http://fr.dbpedia.org/resource/Col_de_l'Alpette,Col de l'Alpette,5.91889,45.4419,1547.0,Chartreuse,col,5,Col de l'Alpette,Chartreuse
+165,http://fr.dbpedia.org/resource/Col_de_l'Arzelier,Col de l'Arzelier,5.59556,44.9911,1154.0,Vercors,col,5,Col de l'Arzelier,Vercors
+115,http://fr.dbpedia.org/resource/Col_de_l'Émeindras,Col de l'Émeindras,5.80389,45.2833,1372.0,Chartreuse,col,5,Col de l'Émeindras,Chartreuse
+132,http://fr.dbpedia.org/resource/Col_de_l'Épine_(Haute-Savoie),Col de l'Épine,6.34889,45.7792,947.0,Aravis,col,5,Col de l'Épine,Aravis
+100,http://fr.dbpedia.org/resource/Col_de_la_Bataille_(Vercors),Col de la Bataille,5.23197,44.8974,1313.0,Vercors,col,5,Col de la Bataille,Vercors
+23,http://fr.dbpedia.org/resource/Col_de_la_Bonette,Col de la Bonette,6.807,44.327,2715.0,Mercantour,col,5,Col de la Bonette,Mercantour
+32,http://fr.dbpedia.org/resource/Col_de_la_Cayolle,Col de la Cayolle,6.74389,44.2589,2326.0,Pelat,col,5,Col de la Cayolle,Pelat
+101,http://fr.dbpedia.org/resource/Col_de_la_Charmette,Col de la Charmette,5.7401,45.3219,1261.0,Chartreuse,col,5,Col de la Charmette,Chartreuse
+166,http://fr.dbpedia.org/resource/Col_de_la_Chau,Col de la Chau,5.35667,44.9072,1337.0,Vercors,col,5,Col de la Chau,Vercors
+82,http://fr.dbpedia.org/resource/Col_de_la_Cluse,Col de la Cluse,5.85917,45.4539,1169.0,Chartreuse,col,5,Col de la Cluse,Chartreuse
+83,http://fr.dbpedia.org/resource/Col_de_la_Colle-Saint-Michel,Col de la Colle-Saint-Michel,6.59333,44.0467,1431.0,Préalpes de Castellane,col,5,Col de la Colle-Saint-Michel,Préalpes de Castellane
+57,http://fr.dbpedia.org/resource/Col_de_la_Colombière,Col de la Colombière,6.47556,45.9922,1613.0,Bornes,col,5,Col de la Colombière,Bornes
+92,http://fr.dbpedia.org/resource/Col_de_la_Couillole,Col de la Couillole,7.02278,44.1,1678.0,Mercantour,col,5,Col de la Couillole,Mercantour
+133,http://fr.dbpedia.org/resource/Col_de_la_Croix_Fry,Col de la Croix Fry,6.40472,45.8767,1467.0,Aravis,col,5,Col de la Croix Fry,Aravis
+167,http://fr.dbpedia.org/resource/Col_de_la_Croix-Perrin,Col de la Croix-Perrin,5.55972,45.13,1218.0,Vercors,col,5,Col de la Croix-Perrin,Vercors
+138,http://fr.dbpedia.org/resource/Col_de_la_Doria,Col de la Doria,5.98917,45.6068,1110.0,Bauges,col,5,Col de la Doria,Bauges
+35,http://fr.dbpedia.org/resource/Col_de_la_Leisse,Col de la Leisse,6.90806,45.4247,2761.0,Vanoise,col,5,Col de la Leisse,Vanoise
+71,http://fr.dbpedia.org/resource/Col_de_la_Machine,Col de la Machine,5.33389,44.9761,1011.0,Vercors,col,5,Col de la Machine,Vercors
+116,http://fr.dbpedia.org/resource/Col_de_la_Mort_d'Imbert,Col de la Mort d'Imbert,5.77889,43.8633,591.0,Luberon,col,5,Col de la Mort d'Imbert,Luberon
+135,http://fr.dbpedia.org/resource/Col_de_la_Perche_(Savoie),Col de la Perche,6.21139,45.4281,1984.0,Belledonne,col,5,Col de la Perche,Belledonne
+78,http://fr.dbpedia.org/resource/Col_de_la_Pisse,Col de la Pisse,6.17944,44.7125,2354.0,Écrins,col,5,Col de la Pisse,Écrins
+48,http://fr.dbpedia.org/resource/Col_de_la_Placette,Col de la Placette,5.65833,45.3297,587.0,Chartreuse,col,5,Col de la Placette,Chartreuse
+54,http://fr.dbpedia.org/resource/Col_de_la_Ponsonnière,Col de la Ponsonnière,6.4661,45.0547,2613.0,Cerces,col,5,Col de la Ponsonnière,Cerces
+168,http://fr.dbpedia.org/resource/Col_de_la_Portette,Col de la Portette,5.29472,44.9567,1175.0,Vercors,col,5,Col de la Portette,Vercors
+8,http://fr.dbpedia.org/resource/Col_de_la_Ramaz,Col de la Ramaz,6.57472,46.1633,1559.0,Chablais,col,5,Col de la Ramaz,Chablais
+14,http://fr.dbpedia.org/resource/Col_de_la_Rochette_(Alpes),Col de la Rochette,5.29417,44.9778,1009.0,Vercors,col,5,Col de la Rochette,Vercors
+139,http://fr.dbpedia.org/resource/Col_de_la_Rousse,Col de la Rousse,6.44333,44.4683,2147.0,Parpaillon,col,5,Col de la Rousse,Parpaillon
+85,http://fr.dbpedia.org/resource/Col_de_la_Ruchère,Col de la Ruchère,5.79806,45.3864,1407.0,Chartreuse,col,5,Col de la Ruchère,Chartreuse
+95,http://fr.dbpedia.org/resource/Col_de_la_Seigne,Col de la Seigne,6.80722,45.7514,2516.0,Mont-Blanc,col,5,Col de la Seigne,Mont-Blanc
+154,http://fr.dbpedia.org/resource/Col_des_Arces,Col des Arces,6.49222,46.2683,1163.0,Chablais,col,5,Col des Arces,Chablais
+15,http://fr.dbpedia.org/resource/Col_des_Ayes,Col des Ayes,5.8425,45.3103,1538.0,Chartreuse,col,5,Col des Ayes,Chartreuse
+72,http://fr.dbpedia.org/resource/Col_des_Champs,Col des Champs,6.70139,44.1781,2089.0,Pelat,col,5,Col des Champs,Pelat
+93,http://fr.dbpedia.org/resource/Col_des_Gets,Col des Gets,6.66667,46.1569,1170.0,Chablais,col,5,Col des Gets,Chablais
+42,http://fr.dbpedia.org/resource/Col_des_Grandes_Jorasses,Col des Grandes Jorasses,6.97389,45.8678,3825.0,Mont-Blanc,col,5,Col des Grandes Jorasses,Mont-Blanc
+142,http://fr.dbpedia.org/resource/Col_des_Granons,Col des Granons,5.68,43.8642,489.0,Luberon,col,5,Col des Granons,Luberon
+156,http://fr.dbpedia.org/resource/Col_des_Limouches,Col des Limouches,5.15833,44.8869,1086.0,Vercors,col,5,Col des Limouches,Vercors
+73,http://fr.dbpedia.org/resource/Col_des_Moises,Col des Moises,6.46694,46.2775,1121.0,Chablais,col,5,Col des Moises,Chablais
+104,http://fr.dbpedia.org/resource/Col_des_Montets,Col des Montets,6.92335,46.0035,1461.0,Mont-Blanc,col,5,Col des Montets,Mont-Blanc
+129,http://fr.dbpedia.org/resource/Col_des_Prés,Col des Prés,6.06111,45.5958,1135.0,Bauges,col,5,Col des Prés,Bauges
+41,http://fr.dbpedia.org/resource/Col_des_Robines,Col des Robines,6.49333,43.9614,988.0,Trois-Évêchés,col,5,Col des Robines,Trois-Évêchés
+49,http://fr.dbpedia.org/resource/Col_des_Égaux,Col des Égaux,5.81167,45.4442,958.0,Chartreuse,col,5,Col des Égaux,Chartreuse
+50,http://fr.dbpedia.org/resource/Col_du_Bonhomme_(Alpes),Col du Bonhomme (Alpes),6.70667,45.735,2329.0,Mont-Blanc,col,5,Col du Bonhomme,Mont-Blanc
+170,http://fr.dbpedia.org/resource/Col_du_Chaussy,Col du Chaussy,6.35647,45.3438,1533.0,Vanoise,col,5,Col du Chaussy,Vanoise
+105,http://fr.dbpedia.org/resource/Col_du_Coq,Col du Coq,5.83663,45.3025,1434.0,Chartreuse,col,5,Col du Coq,Chartreuse
+51,http://fr.dbpedia.org/resource/Col_du_Corbier,Col du Corbier,6.64444,46.2836,1237.0,Chablais,col,5,Col du Corbier,Chablais
+106,http://fr.dbpedia.org/resource/Col_du_Cucheron,Col du Cucheron,5.83445,45.3654,1139.0,Chartreuse,col,5,Col du Cucheron,Chartreuse
+124,http://fr.dbpedia.org/resource/Col_du_Fanget,Col du Fanget,6.3275,44.3278,1459.0,Préalpes de Digne,col,5,Col du Fanget,Préalpes de Digne
+63,http://fr.dbpedia.org/resource/Col_du_Fau,Col du Fau,5.62606,44.9062,899.0,Vercors,col,5,Col du Fau,Vercors
+64,http://fr.dbpedia.org/resource/Col_du_Festre,Col du Festre,5.85843,44.6671,1442.0,Dévoluy,col,5,Col du Festre,Dévoluy
+9,http://fr.dbpedia.org/resource/Col_du_Feu,Col du Feu,6.50889,46.2944,1120.0,Chablais,col,5,Col du Feu,Chablais
+121,http://fr.dbpedia.org/resource/Col_du_Fréjus,Col du Fréjus,6.67389,45.1306,2540.0,Mont-Cenis,col,5,Col du Fréjus,Mont-Cenis
+146,http://fr.dbpedia.org/resource/Col_du_Frêt,Col du Frêt,5.81917,45.3867,1750.0,Chartreuse,col,5,Col du Frêt,Chartreuse
+157,http://fr.dbpedia.org/resource/Col_du_Grand_Cucheron,Col du Grand Cucheron,6.248,45.49,1188.0,Belledonne,col,5,Col du Grand Cucheron,Belledonne
+108,http://fr.dbpedia.org/resource/Col_du_Granier,Col du Granier,5.91515,45.4806,1134.0,Chartreuse,col,5,Col du Granier,Chartreuse
+19,http://fr.dbpedia.org/resource/Col_du_Grapillon,Col du Grapillon,5.84167,45.4628,1509.0,Chartreuse,col,5,Col du Grapillon,Chartreuse
+10,http://fr.dbpedia.org/resource/Col_du_Géant,Col du Géant,6.93472,45.8489,3365.0,Mont-Blanc,col,5,Col du Géant,Mont-Blanc
+16,http://fr.dbpedia.org/resource/Col_du_Jandri,Col du Jandri,6.20306,44.9983,3150.0,Écrins,col,5,Col du Jandri,Écrins
+130,http://fr.dbpedia.org/resource/Col_du_Joly,Col du Joly,6.67389,45.7839,1989.0,Beaufortain,col,5,Col du Joly,Beaufortain
+117,http://fr.dbpedia.org/resource/Col_du_Lausfer,Col du Lausfer,7.09083,44.2217,2430.0,Mercantour,col,5,Col du Lausfer,Mercantour
+113,http://fr.dbpedia.org/resource/Col_du_Longet,Col du Longet,6.95361,44.6431,2647.0,Chambeyron,col,5,Col du Longet,Chambeyron
+52,http://fr.dbpedia.org/resource/Col_du_Mollard,Col du Mollard,6.33667,45.2103,1630.0,Arves,col,5,Col du Mollard,Arves
+143,http://fr.dbpedia.org/resource/Col_du_Mollard_(Chartreuse),Col du Mollard (Chartreuse),5.86722,45.4836,1320.0,Chartreuse,col,5,Col du Mollard,Chartreuse
+65,http://fr.dbpedia.org/resource/Col_du_Noyer,Col du Noyer,5.98519,44.6919,1664.0,Dévoluy,col,5,Col du Noyer,Dévoluy
+86,http://fr.dbpedia.org/resource/Col_du_Petit_Mont-Cenis,Col du Petit Mont-Cenis,6.86528,45.2106,2183.0,Mont-Cenis,col,5,Col du Petit Mont-Cenis,Mont-Cenis
+46,http://fr.dbpedia.org/resource/Col_du_Pilon,Col du Pilon,6.88291,43.6852,780.0,Préalpes de Castellane,col,5,Col du Pilon,Préalpes de Castellane
+11,http://fr.dbpedia.org/resource/Col_du_Pointu,Col du Pointu,5.35111,43.8356,499.0,Luberon,col,5,Col du Pointu,Luberon
+79,http://fr.dbpedia.org/resource/Col_du_Viallet,Col du Viallet,6.15861,44.705,2240.0,Écrins,col,5,Col du Viallet,Écrins
+856,http://fr.dbpedia.org/resource/Colline_de_Lémenc,Colline de Lémenc,5.9325,45.5956,558.0,Bauges,sommet,5,Colline de Lémenc,Bauges
+548,http://fr.dbpedia.org/resource/Connex_(sommet),Connex (sommet),5.74167,45.0461,1360.0,Taillefer,sommet,5,Connex,Taillefer
+34,http://fr.dbpedia.org/resource/Cormet_de_Roselend,Cormet de Roselend,6.69065,45.6912,1968.0,Mont-Blanc,col,5,Cormet de Roselend,Mont-Blanc
+328,http://fr.dbpedia.org/resource/Corne_au_Taureau,Corne au Taureau,6.80944,46.1272,2630.0,Giffre,sommet,5,Corne au Taureau,Giffre
+572,http://fr.dbpedia.org/resource/Cornebois,Cornebois,6.80889,46.2114,2200.0,Chablais,sommet,5,Cornebois,Chablais
+377,http://fr.dbpedia.org/resource/Cornettes_de_Bise,Cornettes de Bise,6.78444,46.3325,2432.0,Chablais,sommet,5,Cornettes de Bise,Chablais
+316,http://fr.dbpedia.org/resource/Cousson,Cousson,6.24,44.0536,1516.0,Trois-Évêchés,sommet,5,Cousson,Trois-Évêchés
+697,http://fr.dbpedia.org/resource/Croise_Baulet,Croise Baulet,6.55222,45.8983,2236.0,Aravis,sommet,5,Croise Baulet,Aravis
+851,http://fr.dbpedia.org/resource/Croix_Rousse_(montagne),Croix Rousse (montagne),7.13194,45.2608,3541.0,Alpes grées,sommet,5,Croix Rousse,Alpes grées
+815,http://fr.dbpedia.org/resource/Croix_des_Têtes,Croix des Têtes,6.4425,45.2669,2492.0,Vanoise,sommet,5,Croix des Têtes,Vanoise
+483,http://fr.dbpedia.org/resource/Crêt_Luisard,Crêt Luisard,6.05444,45.3181,1803.0,Belledonne,sommet,5,Crêt Luisard,Belledonne
+484,http://fr.dbpedia.org/resource/Crêt_du_Poulet,Crêt du Poulet,6.06,45.33,1726.0,Belledonne,sommet,5,Crêt du Poulet,Belledonne
+764,http://fr.dbpedia.org/resource/Crêt_du_Rey,Crêt du Rey,6.56583,45.6019,2633.0,Beaufortain,sommet,5,Crêt du Rey,Beaufortain
+765,http://fr.dbpedia.org/resource/Crête_des_Gittes,Crête des Gittes,6.70833,45.7119,2538.0,Beaufortain,sommet,5,Crête des Gittes,Beaufortain
+766,http://fr.dbpedia.org/resource/Cuguyons,Cuguyons,6.19972,43.6769,982.0,Préalpes de Castellane,sommet,5,Cuguyons,Préalpes de Castellane
+509,http://fr.dbpedia.org/resource/Dent_d'Oche,Dent d'Oche,6.73111,46.3531,2221.0,Chablais,sommet,5,Dent d'Oche,Chablais
+550,http://fr.dbpedia.org/resource/Dent_de_Cons,Dent de Cons,6.35111,45.7297,2062.0,Bauges,sommet,5,Dent de Cons,Bauges
+485,http://fr.dbpedia.org/resource/Dent_de_l'Ours,Dent de l'Ours,5.82083,45.3886,1820.0,Chartreuse,sommet,5,Dent de l'Ours,Chartreuse
+767,http://fr.dbpedia.org/resource/Dent_du_Caïman,Dent du Caïman,6.90889,45.8944,3554.0,Aiguilles de Chamonix,sommet,5,Dent du Caïman,Aiguilles de Chamonix
+551,http://fr.dbpedia.org/resource/Dent_du_Géant,Dent du Géant,6.95167,45.8619,4013.0,Mont-Blanc,sommet,5,Dent du Géant,Mont-Blanc
+423,http://fr.dbpedia.org/resource/Dent_du_Requin,Dent du Requin,6.9175,45.8878,3422.0,Aiguilles de Chamonix,sommet,5,Dent du Requin,Aiguilles de Chamonix
+357,http://fr.dbpedia.org/resource/Dent_du_Vélan,Dent du Vélan,6.77486,46.3472,2059.0,Chablais,sommet,5,Dent du Vélan,Chablais
+573,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+574,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+575,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+576,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+577,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+578,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+579,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+580,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+581,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1216,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+582,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+583,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+584,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+585,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+586,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+587,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+588,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+589,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+590,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1233,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+591,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+592,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+593,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+594,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+595,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+596,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+597,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+598,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+599,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1363,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+600,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+601,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+602,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+603,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+604,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+605,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+606,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+607,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+608,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1369,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+609,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+610,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+611,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+612,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+613,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+614,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+615,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+616,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+617,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1372,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+618,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+619,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+620,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+621,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+622,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+623,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+624,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+625,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+626,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1794,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+627,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+628,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+629,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+630,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+631,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+632,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+633,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+634,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+635,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.1993,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+636,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+637,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+638,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+639,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+640,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+641,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+642,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+643,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+644,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.2057,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+645,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.01217,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+646,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.0236,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+647,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.02865,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+648,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06056,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+649,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.06448,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+650,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.08387,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+651,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09944,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+652,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.09992,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+653,http://fr.dbpedia.org/resource/Dentelles_de_Montmirail,Dentelles de Montmirail,5.10032,44.2167,730.0,Monts de Vaucluse,sommet,5,Dentelles de Montmirail,Monts de Vaucluse
+685,http://fr.dbpedia.org/resource/Dents_de_Lanfon,Dents de Lanfon,6.24167,45.8611,1824.0,Bornes,sommet,5,Dents de Lanfon,Bornes
+211,http://fr.dbpedia.org/resource/Domaine_skiable_de_Villard-de-Lans_Corrençon-en-Vercors,Domaine skiable de Villard-de-Lans Corrençon-en-Vercors,5.55672,45.0471,0.0,Vercors,ski,5,Domaine skiable de Villard-de-Lans Corrençon-en-Vercors,
+711,http://fr.dbpedia.org/resource/Dôme_de_Barrot,Dôme de Barrot,6.91667,44.0367,2137.0,Mercantour,sommet,5,Dôme de Barrot,Mercantour
+503,http://fr.dbpedia.org/resource/Dôme_de_Bellefont,Dôme de Bellefont,5.88111,45.3419,1975.0,Chartreuse,sommet,5,Dôme de Bellefont,Chartreuse
+462,http://fr.dbpedia.org/resource/Dôme_de_Chasseforêt,Dôme de Chasseforêt,6.76056,45.3306,3586.0,Vanoise,sommet,5,Dôme de Chasseforêt,Vanoise
+491,http://fr.dbpedia.org/resource/Dôme_de_Monêtier,Dôme de Monêtier,6.4525,44.9308,3404.0,Écrins,sommet,5,Dôme de Monêtier,Écrins
+768,http://fr.dbpedia.org/resource/Dôme_de_Polset,Dôme de Polset,6.64028,45.2764,3501.0,Vanoise,sommet,5,Dôme de Polset,Vanoise
+816,http://fr.dbpedia.org/resource/Dôme_de_Rochefort,Dôme de Rochefort,6.9675,45.8642,4015.0,Mont-Blanc,sommet,5,Dôme de Rochefort,Mont-Blanc
+769,http://fr.dbpedia.org/resource/Dôme_de_l'Arpont,Dôme de l'Arpont,6.74278,45.3186,3601.0,Vanoise,sommet,5,Dôme de l'Arpont,Vanoise
+400,http://fr.dbpedia.org/resource/Dôme_de_la_Sache,Dôme de la Sache,6.87056,45.5111,3601.0,Vanoise,sommet,5,Dôme de la Sache,Vanoise
+770,http://fr.dbpedia.org/resource/Dôme_des_Nants,Dôme des Nants,6.74139,45.3264,3570.0,Vanoise,sommet,5,Dôme des Nants,Vanoise
+771,http://fr.dbpedia.org/resource/Dôme_des_Pichères,Dôme des Pichères,6.79833,45.4917,3319.0,Vanoise,sommet,5,Dôme des Pichères,Vanoise
+401,http://fr.dbpedia.org/resource/Dôme_des_Platières,Dôme des Platières,6.86389,45.5075,3473.0,Vanoise,sommet,5,Dôme des Platières,Vanoise
+772,http://fr.dbpedia.org/resource/Dôme_des_Sonnailles,Dôme des Sonnailles,6.74556,45.3458,3361.0,Vanoise,sommet,5,Dôme des Sonnailles,Vanoise
+296,http://fr.dbpedia.org/resource/Dômes_de_Miage,Dômes de Miage,6.8,45.8158,3673.0,Mont-Blanc,sommet,5,Dômes de Miage,Mont-Blanc
+220,http://fr.dbpedia.org/resource/Espace_Diamant,Espace Diamant,6.5542,45.7945,990.0,0,ski,5,Espace Diamant,
+213,http://fr.dbpedia.org/resource/Espace_Killy,Espace Killy,6.77089,45.6194,0.0,Alpes du Nord,ski,5,Espace Killy,
+74,http://fr.dbpedia.org/resource/Faux_col_de_Restefond,Faux col de Restefond,6.80139,44.3369,2656.0,Mercantour,col,5,Faux col de Restefond,Mercantour
+690,http://fr.dbpedia.org/resource/Fort_Carra,Fort Carra,6.8075,44.2456,2880.0,Mercantour,sommet,5,Fort Carra,Mercantour
+276,http://fr.dbpedia.org/resource/Galibier-Thabor,Galibier-Thabor,6.42917,45.1658,0.0,0,ski,5,Galibier-Thabor,
+17,http://fr.dbpedia.org/resource/Golet_de_Doucy,Golet de Doucy,6.17722,45.7175,1329.0,Bauges,col,5,Golet de Doucy,Bauges
+552,http://fr.dbpedia.org/resource/Goléon,Goléon,6.32639,45.1036,3427.0,Arves,sommet,5,Goléon,Arves
+731,http://fr.dbpedia.org/resource/Grand_Arc,Grand Arc,6.36472,45.5664,2484.0,Lauzière,sommet,5,Grand Arc,Lauzière
+309,http://fr.dbpedia.org/resource/Grand_Armet,Grand Armet,5.93444,44.9811,2792.0,Taillefer,sommet,5,Grand Armet,Taillefer
+310,http://fr.dbpedia.org/resource/Grand_Aréa,Grand Aréa,6.57278,44.98,2869.0,Cerces,sommet,5,Grand Aréa,Cerces
+857,http://fr.dbpedia.org/resource/Grand_Assaly,Grand Assaly,6.97028,45.6542,3173.0,Alpes grées,sommet,5,Grand Assaly,Alpes grées
+773,http://fr.dbpedia.org/resource/Grand_Bec,Grand Bec,6.75278,45.4236,3398.0,Vanoise,sommet,5,Grand Bec,Vanoise
+654,http://fr.dbpedia.org/resource/Grand_Bérard,Grand Bérard,6.66,44.4494,3046.0,Parpaillon,sommet,5,Grand Bérard,Parpaillon
+843,http://fr.dbpedia.org/resource/Grand_Capelet,Grand Capelet,7.42722,44.0783,2935.0,Mercantour,sommet,5,Grand Capelet,Mercantour
+311,http://fr.dbpedia.org/resource/Grand_Capucin,Grand Capucin,6.89806,45.8517,3838.0,Mont-Blanc,sommet,5,Grand Capucin,Mont-Blanc
+324,http://fr.dbpedia.org/resource/Grand_Charnier_d'Allemond,Grand Charnier d'Allemond,5.99667,45.155,2777.0,Belledonne,sommet,5,Grand Charnier d'Allemond,Belledonne
+297,http://fr.dbpedia.org/resource/Grand_Cheval_de_Bois,Grand Cheval de Bois,6.63333,44.2919,2838.0,Pelat,sommet,5,Grand Cheval de Bois,Pelat
+408,http://fr.dbpedia.org/resource/Grand_Coyer,Grand Coyer,6.68972,44.1003,2693.0,Pelat,sommet,5,Grand Coyer,Pelat
+382,http://fr.dbpedia.org/resource/Grand_Ferrand,Grand Ferrand,5.815,44.7219,2758.0,Dévoluy,sommet,5,Grand Ferrand,Dévoluy
+553,http://fr.dbpedia.org/resource/Grand_Galbert,Grand Galbert,5.95944,45.0906,2561.0,Taillefer,sommet,5,Grand Galbert,Taillefer
+554,http://fr.dbpedia.org/resource/Grand_Galibier,Grand Galibier,6.43389,45.0642,3228.0,Cerces,sommet,5,Grand Galibier,Cerces
+476,http://fr.dbpedia.org/resource/Grand_Glaiza,Grand Glaiza,6.88194,44.8494,3293.0,Queyras,sommet,5,Grand Glaiza,Queyras
+663,http://fr.dbpedia.org/resource/Grand_Margès,Grand Margès,6.27861,43.7556,1576.0,Préalpes de Castellane,sommet,5,Grand Margès,Préalpes de Castellane
+774,http://fr.dbpedia.org/resource/Grand_Mont,Grand Mont,6.53667,45.6319,2686.0,Beaufortain,sommet,5,Grand Mont,Beaufortain
+775,http://fr.dbpedia.org/resource/Grand_Roc,Grand Roc,6.68806,45.2656,3316.0,Vanoise,sommet,5,Grand Roc,Vanoise
+486,http://fr.dbpedia.org/resource/Grand_Rocher,Grand Rocher,6.05,45.3036,1926.0,Belledonne,sommet,5,Grand Rocher,Belledonne
+555,http://fr.dbpedia.org/resource/Grand_Serre,Grand Serre,5.82639,45.0056,2141.0,Taillefer,sommet,5,Grand Serre,Taillefer
+556,http://fr.dbpedia.org/resource/Grand_pic_de_Belledonne,Grand pic de Belledonne,5.99167,45.1711,2977.0,Belledonne,sommet,5,Grand pic de Belledonne,Belledonne
+732,http://fr.dbpedia.org/resource/Grand_pic_de_la_Lauzière,Grand pic de la Lauzière,6.36639,45.4592,2829.0,Lauzière,sommet,5,Grand pic de la Lauzière,Lauzière
+776,http://fr.dbpedia.org/resource/Grand_roc_Noir,Grand roc Noir,6.89167,45.3303,3582.0,Vanoise,sommet,5,Grand roc Noir,Vanoise
+664,http://fr.dbpedia.org/resource/Grande_Balmaz,Grande Balmaz,6.49639,45.8931,2616.0,Aravis,sommet,5,Grande Balmaz,Aravis
+298,http://fr.dbpedia.org/resource/Grande_Bosse,Grande Bosse,6.85583,45.8353,4513.0,Mont-Blanc,sommet,5,Grande Bosse,Mont-Blanc
+777,http://fr.dbpedia.org/resource/Grande_Lance_de_Domène,Grande Lance de Domène,5.95917,45.1714,2790.0,Belledonne,sommet,5,Grande Lance de Domène,Belledonne
+733,http://fr.dbpedia.org/resource/Grande_Motte,Grande Motte,6.87028,45.4111,3653.0,Vanoise,sommet,5,Grande Motte,Vanoise
+778,http://fr.dbpedia.org/resource/Grande_Parel,Grande Parel,6.64222,45.6272,2725.0,Beaufortain,sommet,5,Grande Parel,Beaufortain
+817,http://fr.dbpedia.org/resource/Grande_Rocheuse,Grande Rocheuse,6.97278,45.9344,4102.0,Mont-Blanc,sommet,5,Grande Rocheuse,Mont-Blanc
+522,http://fr.dbpedia.org/resource/Grande_Ruine,Grande Ruine,6.32889,44.9675,3765.0,Écrins,sommet,5,Grande Ruine,Écrins
+523,http://fr.dbpedia.org/resource/Grande_Sure,Grande Sure,5.70333,45.3353,1920.0,Chartreuse,sommet,5,Grande Sure,Chartreuse
+752,http://fr.dbpedia.org/resource/Grande_Séolane,Grande Séolane,6.54583,44.3375,2909.0,Trois-Évêchés,sommet,5,Grande Séolane,Trois-Évêchés
+721,http://fr.dbpedia.org/resource/Grande_aiguille_Rousse,Grande aiguille Rousse,7.1096,45.4329,3482.0,Alpes grées,sommet,5,Grande aiguille Rousse,Alpes grées
+524,http://fr.dbpedia.org/resource/Grande_aiguille_de_la_Bérarde,Grande aiguille de la Bérarde,6.2775,44.9161,3421.0,Écrins,sommet,5,Grande aiguille de la Bérarde,Écrins
+665,http://fr.dbpedia.org/resource/Grands_Crêts,Grands Crêts,5.81361,45.2711,1489.0,Chartreuse,sommet,5,Grands Crêts,Chartreuse
+317,http://fr.dbpedia.org/resource/Grenier_de_Commune,Grenier de Commune,6.83306,46.0456,2775.0,Giffre,sommet,5,Grenier de Commune,Giffre
+858,http://fr.dbpedia.org/resource/Gros_Rognon,Gros Rognon,6.90444,45.8683,3541.0,Mont-Blanc,sommet,5,Gros Rognon,Mont-Blanc
+852,http://fr.dbpedia.org/resource/Grun_de_Saint-Maurice,Grun de Saint-Maurice,6.05639,44.8158,2775.0,Écrins,sommet,5,Grun de Saint-Maurice,Écrins
+278,http://fr.dbpedia.org/resource/Habère-Poche,Habère-Poche,6.47333,46.2497,0.0,0,ski,5,Habère-Poche,
+409,http://fr.dbpedia.org/resource/Haute-Pointe,Haute-Pointe,6.54972,46.1753,1958.0,Chablais,sommet,5,Haute-Pointe,Chablais
+734,http://fr.dbpedia.org/resource/Hauts-Forts,Hauts-Forts,6.7775,46.1686,2466.0,Chablais,sommet,5,Hauts-Forts,Chablais
+735,http://fr.dbpedia.org/resource/Jocou,Jocou,5.6475,44.7244,2051.0,Diois,sommet,5,Jocou,Diois
+525,http://fr.dbpedia.org/resource/L'Ailefroide,L'Ailefroide,6.35667,44.885,3954.0,Écrins,sommet,5,L'Ailefroide,Écrins
+526,http://fr.dbpedia.org/resource/L'Olan,L'Olan,6.19667,44.8589,3564.0,Écrins,sommet,5,L'Olan,Écrins
+504,http://fr.dbpedia.org/resource/La_Buffe,La Buffe,5.58417,45.2439,1623.0,Vercors,sommet,5,La Buffe,Vercors
+365,http://fr.dbpedia.org/resource/La_Cochette,La Cochette,5.83556,45.4553,1618.0,Chartreuse,sommet,5,La Cochette,Chartreuse
+492,http://fr.dbpedia.org/resource/La_Cucumelle,La Cucumelle,6.50889,44.9381,2698.0,Écrins,sommet,5,La Cucumelle,Écrins
+329,http://fr.dbpedia.org/resource/La_Grande_Pointe,La Grande Pointe,6.58972,46.2181,1802.0,Chablais,sommet,5,La Grande Pointe,Chablais
+235,http://fr.dbpedia.org/resource/La_Grande-Terche,La Grande-Terche,6.63417,46.2142,950.0,0,ski,5,La Grande-Terche,
+227,http://fr.dbpedia.org/resource/La_Rosière_(Montvalezan),La Rosière (Montvalezan),6.84793,45.6288,1850.0,0,ski,5,La Rosière,
+366,http://fr.dbpedia.org/resource/La_Scia,La Scia,5.85083,45.3489,1791.0,Chartreuse,sommet,5,La Scia,Chartreuse
+505,http://fr.dbpedia.org/resource/La_Sure,La Sure,5.59778,45.2353,1643.0,Vercors,sommet,5,La Sure,Vercors
+493,http://fr.dbpedia.org/resource/La_Tour_Ronde,La Tour Ronde,6.9075,45.8439,3792.0,Mont-Blanc,sommet,5,La Tour Ronde,Mont-Blanc
+442,http://fr.dbpedia.org/resource/La_Tournette,La Tournette,6.28611,45.8272,2351.0,Bornes,sommet,5,La Tournette,Bornes
+318,http://fr.dbpedia.org/resource/Lancebranlette,Lancebranlette,6.85611,45.6853,2936.0,Mont-Blanc,sommet,5,Lancebranlette,Mont-Blanc
+390,http://fr.dbpedia.org/resource/Lances_de_Malissard,Lances de Malissard,5.87333,45.3467,2045.0,Chartreuse,sommet,5,Lances de Malissard,Chartreuse
+557,http://fr.dbpedia.org/resource/Le_Brévent,Le Brévent,6.83778,45.9342,2525.0,Aiguilles Rouges,sommet,5,Le Brévent,Aiguilles Rouges
+330,http://fr.dbpedia.org/resource/Le_Cheval_Blanc_(sommet),Le Cheval Blanc (sommet),6.87278,46.0519,2831.0,Giffre,sommet,5,Le Cheval Blanc,Giffre
+236,http://fr.dbpedia.org/resource/Le_Corbier,Le Corbier,6.28333,45.25,1550.0,0,ski,5,Le Corbier,
+844,http://fr.dbpedia.org/resource/Le_Drouvet,Le Drouvet,6.3175,44.7211,2655.0,Écrins,sommet,5,Le Drouvet,Écrins
+402,http://fr.dbpedia.org/resource/Le_Fifre,Le Fifre,6.35667,44.9167,3699.0,Écrins,sommet,5,Le Fifre,Écrins
+859,http://fr.dbpedia.org/resource/Le_Grand_Manti,Le Grand Manti,5.90861,45.3847,1818.0,Chartreuse,sommet,5,Le Grand Manti,Chartreuse
+187,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.42583,45.9722,1000.0,Aravis,ski,5,Le Grand-Bornand,
+188,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.45074,45.9722,1000.0,Aravis,ski,5,Le Grand-Bornand,
+190,http://fr.dbpedia.org/resource/Le_Grand-Bornand,Le Grand-Bornand,6.45074,45.9425,1000.0,Aravis,ski,5,Le Grand-Bornand,
+506,http://fr.dbpedia.org/resource/Le_Marteau,Le Marteau,6.76278,45.9659,2289.0,Giffre,sommet,5,Le Marteau,Giffre
+374,http://fr.dbpedia.org/resource/Le_Môle,Le Môle,6.455,46.1067,1863.0,Chablais,sommet,5,Le Môle,Chablais
+325,http://fr.dbpedia.org/resource/Le_Pavé,Le Pavé,6.32389,44.9986,3823.0,Écrins,sommet,5,Le Pavé,Écrins
+527,http://fr.dbpedia.org/resource/Le_Plaret,Le Plaret,6.25889,44.9681,3563.0,Écrins,sommet,5,Le Plaret,Écrins
+391,http://fr.dbpedia.org/resource/Le_Râteau,Le Râteau,6.28056,45.0011,3809.0,Écrins,sommet,5,Le Râteau,Écrins
+529,http://fr.dbpedia.org/resource/Les_Bans,Les Bans,6.33611,44.8483,3669.0,Écrins,sommet,5,Les Bans,Écrins
+228,http://fr.dbpedia.org/resource/Les_Bottières,Les Bottières,6.29748,45.2667,1300.0,0,ski,5,Les Bottières,
+494,http://fr.dbpedia.org/resource/Les_Courtes,Les Courtes,7.00347,45.9275,3856.0,Mont-Blanc,sommet,5,Les Courtes,Mont-Blanc
+312,http://fr.dbpedia.org/resource/Les_Droites,Les Droites,6.98917,45.9303,4000.0,Mont-Blanc,sommet,5,Les Droites,Mont-Blanc
+443,http://fr.dbpedia.org/resource/Les_Drus,Les Drus,6.95639,45.9328,3754.0,Mont-Blanc,sommet,5,Les Drus,Mont-Blanc
+716,http://fr.dbpedia.org/resource/Les_Monges,Les Monges,6.19417,44.2628,2115.0,Préalpes de Digne,sommet,5,Les Monges,Préalpes de Digne
+530,http://fr.dbpedia.org/resource/Les_Rouies,Les Rouies,6.25806,44.8636,3589.0,Écrins,sommet,5,Les Rouies,Écrins
+226,http://fr.dbpedia.org/resource/Les_Sybelles,Les Sybelles,6.29036,45.2365,1100.0,0,ski,5,Les Sybelles,
+209,http://fr.dbpedia.org/resource/Les_Trois_Vallées,Les Trois Vallées,6.5733,45.3647,0.0,Vanoise,ski,5,Les Trois Vallées,
+779,http://fr.dbpedia.org/resource/Les_Voirons,Les Voirons,6.35528,46.2306,1480.0,Chablais,sommet,5,Les Voirons,Chablais
+845,http://fr.dbpedia.org/resource/Levanna,Levanna,7.17194,45.4103,3619.0,Alpes grées,sommet,5,Levanna,Alpes grées
+495,http://fr.dbpedia.org/resource/Massif_d'Uchaux,Massif d'Uchaux,4.81389,44.2311,281.0,Baronnies,sommet,5,Massif d'Uchaux,Baronnies
+403,http://fr.dbpedia.org/resource/Miélandre,Miélandre,5.19639,44.4847,1451.0,Diois,sommet,5,Miélandre,Diois
+444,http://fr.dbpedia.org/resource/Mont_Agel,Mont Agel,7.42639,43.7753,1148.0,Préalpes de Nice,sommet,5,Mont Agel,Préalpes de Nice
+477,http://fr.dbpedia.org/resource/Mont_Aiguillette,Mont Aiguillette,7.02444,44.6911,3287.0,Escreins,sommet,5,Mont Aiguillette,Escreins
+853,http://fr.dbpedia.org/resource/Mont_Beauvoir,Mont Beauvoir,5.79167,45.4767,1320.0,Chartreuse,sommet,5,Mont Beauvoir,Chartreuse
+808,http://fr.dbpedia.org/resource/Mont_Bichet,Mont Bichet,6.53722,46.2781,1360.0,Chablais,sommet,5,Mont Bichet,Chablais
+299,http://fr.dbpedia.org/resource/Mont_Billiat,Mont Billiat,6.58389,46.2883,1894.0,Chablais,sommet,5,Mont Billiat,Chablais
+531,http://fr.dbpedia.org/resource/Mont_Blanc_du_Tacul,Mont Blanc du Tacul,6.88778,45.8567,4248.0,Mont-Blanc,sommet,5,Mont Blanc du Tacul,Mont-Blanc
+666,http://fr.dbpedia.org/resource/Mont_Boron,Mont Boron,7.30083,43.69,191.3,Préalpes de Nice,sommet,5,Mont Boron,Préalpes de Nice
+463,http://fr.dbpedia.org/resource/Mont_Bréquin,Mont Bréquin,6.53361,45.2517,3130.0,Vanoise,sommet,5,Mont Bréquin,Vanoise
+558,http://fr.dbpedia.org/resource/Mont_Buet,Mont Buet,6.8525,46.025,3096.0,Giffre,sommet,5,Mont Buet,Giffre
+453,http://fr.dbpedia.org/resource/Mont_Chaberton,Mont Chaberton,6.75111,44.9644,3131.0,Cerces,sommet,5,Mont Chaberton,Cerces
+667,http://fr.dbpedia.org/resource/Mont_Charvet,Mont Charvet,6.53861,45.9422,2538.0,Aravis,sommet,5,Mont Charvet,Aravis
+510,http://fr.dbpedia.org/resource/Mont_Charvin_(Aravis),Mont Charvin (Aravis),6.42028,45.8025,2409.0,Aravis,sommet,5,Mont Charvin,Aravis
+532,http://fr.dbpedia.org/resource/Mont_Charvin_(Maurienne),Mont Charvin (Maurienne),6.28472,45.2172,2207.0,Arves,sommet,5,Mont Charvin,Arves
+331,http://fr.dbpedia.org/resource/Mont_Chauffé,Mont Chauffé,6.76056,46.3094,2093.0,Chablais,sommet,5,Mont Chauffé,Chablais
+413,http://fr.dbpedia.org/resource/Mont_Chenaillet,Mont Chenaillet,6.74028,44.9022,2650.0,Queyras,sommet,5,Mont Chenaillet,Queyras
+668,http://fr.dbpedia.org/resource/Mont_Chiran,Mont Chiran,6.31667,43.8681,1905.0,Préalpes de Digne,sommet,5,Mont Chiran,Préalpes de Digne
+819,http://fr.dbpedia.org/resource/Mont_Chéry,Mont Chéry,6.64806,46.1689,1826.0,Chablais,sommet,5,Mont Chéry,Chablais
+753,http://fr.dbpedia.org/resource/Mont_Clapier,Mont Clapier,7.42,44.1153,3045.0,Mercantour,sommet,5,Mont Clapier,Mercantour
+686,http://fr.dbpedia.org/resource/Mont_Coin,Mont Coin,6.62056,45.6319,2539.0,Beaufortain,sommet,5,Mont Coin,Beaufortain
+426,http://fr.dbpedia.org/resource/Mont_Colombier,Mont Colombier,6.11944,45.6444,2043.0,Bauges,sommet,5,Mont Colombier,Bauges
+433,http://fr.dbpedia.org/resource/Mont_Colombis,Mont Colombis,6.2175,44.495,1734.0,Alpes,sommet,5,Mont Colombis,Alpes
+669,http://fr.dbpedia.org/resource/Mont_Fleuri_(sommet),Mont Fleuri (sommet),6.53361,45.9328,2511.0,Aravis,sommet,5,Mont Fleuri,Aravis
+417,http://fr.dbpedia.org/resource/Mont_Forchat,Mont Forchat,6.48833,46.2736,1545.0,Chablais,sommet,5,Mont Forchat,Chablais
+736,http://fr.dbpedia.org/resource/Mont_Férion,Mont Férion,7.2725,43.8686,1412.0,Préalpes de Nice,sommet,5,Mont Férion,Préalpes de Nice
+358,http://fr.dbpedia.org/resource/Mont_Giusalet,Mont Giusalet,6.92972,45.1806,3312.0,Mont-Cenis,sommet,5,Mont Giusalet,Mont-Cenis
+418,http://fr.dbpedia.org/resource/Mont_Jalla,Mont Jalla,5.72472,45.2047,635.0,Chartreuse,sommet,5,Mont Jalla,Chartreuse
+487,http://fr.dbpedia.org/resource/Mont_Joigny,Mont Joigny,5.89778,45.4917,1556.0,Chartreuse,sommet,5,Mont Joigny,Chartreuse
+780,http://fr.dbpedia.org/resource/Mont_Joly,Mont Joly,6.69278,45.8258,2525.0,Beaufortain,sommet,5,Mont Joly,Beaufortain
+351,http://fr.dbpedia.org/resource/Mont_Julioz,Mont Julioz,6.16056,45.7072,1662.0,Bauges,sommet,5,Mont Julioz,Bauges
+846,http://fr.dbpedia.org/resource/Mont_Lachat,Mont Lachat,6.35139,45.9275,2023.0,Bornes,sommet,5,Mont Lachat,Bornes
+704,http://fr.dbpedia.org/resource/Mont_Malinvern,Mont Malinvern,7.18889,44.1986,2938.0,Mercantour,sommet,5,Mont Malinvern,Mercantour
+820,http://fr.dbpedia.org/resource/Mont_Mallet,Mont Mallet,6.96056,45.8653,3989.0,Mont-Blanc,sommet,5,Mont Mallet,Mont-Blanc
+470,http://fr.dbpedia.org/resource/Mont_Margériaz,Mont Margériaz,6.03444,45.6358,1845.0,Bauges,sommet,5,Mont Margériaz,Bauges
+533,http://fr.dbpedia.org/resource/Mont_Maudit,Mont Maudit,6.87583,45.8478,4465.0,Mont-Blanc,sommet,5,Mont Maudit,Mont-Blanc
+559,http://fr.dbpedia.org/resource/Mont_Mirantin,Mont Mirantin,6.49889,45.6844,2460.0,Beaufortain,sommet,5,Mont Mirantin,Beaufortain
+393,http://fr.dbpedia.org/resource/Mont_Mounier,Mont Mounier,6.97167,44.1542,2817.0,Mercantour,sommet,5,Mont Mounier,Mercantour
+352,http://fr.dbpedia.org/resource/Mont_Neiglier,Mont Neiglier,7.38694,44.0883,2786.0,Mercantour,sommet,5,Mont Neiglier,Mercantour
+821,http://fr.dbpedia.org/resource/Mont_Orchez,Mont Orchez,6.55056,46.0992,1347.0,Giffre,sommet,5,Mont Orchez,Giffre
+488,http://fr.dbpedia.org/resource/Mont_Outheran,Mont Outheran,5.845,45.4658,1676.0,Chartreuse,sommet,5,Mont Outheran,Chartreuse
+822,http://fr.dbpedia.org/resource/Mont_Ouzon,Mont Ouzon,6.64444,46.2997,1880.0,Chablais,sommet,5,Mont Ouzon,Chablais
+781,http://fr.dbpedia.org/resource/Mont_Pelve,Mont Pelve,6.78139,45.3567,3261.0,Vanoise,sommet,5,Mont Pelve,Vanoise
+823,http://fr.dbpedia.org/resource/Mont_Peney,Mont Peney,5.99,45.5978,1356.0,Bauges,sommet,5,Mont Peney,Bauges
+347,http://fr.dbpedia.org/resource/Mont_Pouzenc,Mont Pouzenc,6.51583,44.4586,2898.0,Parpaillon,sommet,5,Mont Pouzenc,Parpaillon
+512,http://fr.dbpedia.org/resource/Mont_Prorel,Mont Prorel,6.58111,44.9053,2566.0,Écrins,sommet,5,Mont Prorel,Écrins
+655,http://fr.dbpedia.org/resource/Mont_Revard,Mont Revard,5.98972,45.6894,1562.0,Bauges,sommet,5,Mont Revard,Bauges
+670,http://fr.dbpedia.org/resource/Mont_Saint-Eynard,Mont Saint-Eynard,5.79917,45.2597,1379.0,Chartreuse,sommet,5,Mont Saint-Eynard,Chartreuse
+717,http://fr.dbpedia.org/resource/Mont_Saint-Honorat,Mont Saint-Honorat,6.76444,44.0764,2520.0,Pelat,sommet,5,Mont Saint-Honorat,Pelat
+419,http://fr.dbpedia.org/resource/Mont_Serein,Mont Serein,5.26083,44.1853,1437.0,Baronnies,sommet,5,Mont Serein,Baronnies
+847,http://fr.dbpedia.org/resource/Mont_Tondu,Mont Tondu,6.75528,45.7636,3196.0,Mont-Blanc,sommet,5,Mont Tondu,Mont-Blanc
+718,http://fr.dbpedia.org/resource/Mont_Tournairet,Mont Tournairet,7.23389,44.0161,2086.0,Mercantour,sommet,5,Mont Tournairet,Mercantour
+737,http://fr.dbpedia.org/resource/Mont_Turia,Mont Turia,6.86056,45.5325,3650.0,Vanoise,sommet,5,Mont Turia,Vanoise
+313,http://fr.dbpedia.org/resource/Mont_Veyrier,Mont Veyrier,6.1825,45.9006,1291.0,Bornes,sommet,5,Mont Veyrier,Bornes
+395,http://fr.dbpedia.org/resource/Mont_d'Ambin,Mont d'Ambin,6.88417,45.1569,3378.0,Mont-Cenis,sommet,5,Mont d'Ambin,Mont-Cenis
+824,http://fr.dbpedia.org/resource/Mont_d'Arbois,Mont d'Arbois,6.66944,45.8547,1833.0,Beaufortain,sommet,5,Mont d'Arbois,Beaufortain
+825,http://fr.dbpedia.org/resource/Mont_d'Hermone,Mont d'Hermone,6.53222,46.3169,1413.0,Chablais,sommet,5,Mont d'Hermone,Chablais
+826,http://fr.dbpedia.org/resource/Mont_de_Boisy,Mont de Boisy,6.35778,46.3078,739.0,Chablais,sommet,5,Mont de Boisy,Chablais
+739,http://fr.dbpedia.org/resource/Mont_de_Grange,Mont de Grange,6.78056,46.2625,2432.0,Chablais,sommet,5,Mont de Grange,Chablais
+782,http://fr.dbpedia.org/resource/Mont_de_Gébroulaz,Mont de Gébroulaz,6.62917,45.2747,3511.0,Vanoise,sommet,5,Mont de Gébroulaz,Vanoise
+464,http://fr.dbpedia.org/resource/Mont_du_Borgne,Mont du Borgne,6.61333,45.3039,3153.0,Vanoise,sommet,5,Mont du Borgne,Vanoise
+712,http://fr.dbpedia.org/resource/Montagne_d'Angèle,Montagne d'Angèle,5.2575,44.4878,1606.0,Diois,sommet,5,Montagne d'Angèle,Diois
+471,http://fr.dbpedia.org/resource/Montagne_de_Bange,Montagne de Bange,6.03694,45.7297,1434.0,Bauges,sommet,5,Montagne de Bange,Bauges
+456,http://fr.dbpedia.org/resource/Montagne_de_Cordœil,Montagne de Cordœil,6.52944,44.0678,2114.0,Trois-Évêchés,sommet,5,Montagne de Cordœil,Trois-Évêchés
+783,http://fr.dbpedia.org/resource/Montagne_de_Lachens,Montagne de Lachens,6.66111,43.7472,1714.0,Préalpes de Castellane,sommet,5,Montagne de Lachens,Préalpes de Castellane
+434,http://fr.dbpedia.org/resource/Montagne_de_Maurel,Montagne de Maurel,6.52944,44.0117,1770.0,Trois-Évêchés,sommet,5,Montagne de Maurel,Trois-Évêchés
+348,http://fr.dbpedia.org/resource/Montagne_de_la_Loube,Montagne de la Loube,5.99222,43.3689,830.0,Sainte-Baume,sommet,5,Montagne de la Loube,Sainte-Baume
+448,http://fr.dbpedia.org/resource/Montagne_de_la_Mandallaz,Montagne de la Mandallaz,6.08,45.9758,929.0,Préalpes,sommet,5,Montagne de la Mandallaz,Préalpes
+534,http://fr.dbpedia.org/resource/Montagne_des_Agneaux,Montagne des Agneaux,6.42972,44.9503,3664.0,Écrins,sommet,5,Montagne des Agneaux,Écrins
+496,http://fr.dbpedia.org/resource/Montagne_des_Gures,Montagne des Gures,6.7475,45.9308,940.0,Mont-Blanc,sommet,5,Montagne des Gures,Mont-Blanc
+414,http://fr.dbpedia.org/resource/Montagne_des_Mémises,Montagne des Mémises,6.71306,46.3789,1674.0,Chablais,sommet,5,Montagne des Mémises,Chablais
+454,http://fr.dbpedia.org/resource/Montagne_du_Charbon,Montagne du Charbon,6.19028,45.7108,1932.0,Bauges,sommet,5,Montagne du Charbon,Bauges
+671,http://fr.dbpedia.org/resource/Montagne_du_Cheiron,Montagne du Cheiron,6.96944,43.8147,1778.0,Préalpes de Castellane,sommet,5,Montagne du Cheiron,Préalpes de Castellane
+449,http://fr.dbpedia.org/resource/Montagne_du_Cheval_Blanc,Montagne du Cheval Blanc,6.42389,44.1275,2323.0,Trois-Évêchés,sommet,5,Montagne du Cheval Blanc,Trois-Évêchés
+672,http://fr.dbpedia.org/resource/Mourre_de_Chanier,Mourre de Chanier,6.35083,43.8417,1930.0,Préalpes de Digne,sommet,5,Mourre de Chanier,Préalpes de Digne
+785,http://fr.dbpedia.org/resource/Nivolet,Nivolet,5.96556,45.6139,1547.0,Bauges,sommet,5,Nivolet,Bauges
+561,http://fr.dbpedia.org/resource/Négresse_(sommet),Négresse (sommet),6.34222,45.7042,1720.0,Bauges,sommet,5,Négresse,Bauges
+673,http://fr.dbpedia.org/resource/Néron_(Isère),Néron (Isère),5.71,45.2344,1298.0,Chartreuse,sommet,5,Néron,Chartreuse
+253,http://fr.dbpedia.org/resource/Orange_(station_de_sports_d'hiver),Orange (station de sports d'hiver),6.32533,46.0274,0.0,0,ski,5,Orange,
+722,http://fr.dbpedia.org/resource/Ouille_d'Arbéron,Ouille d'Arbéron,7.12778,45.2717,3563.0,Alpes grées,sommet,5,Ouille d'Arbéron,Alpes grées
+726,http://fr.dbpedia.org/resource/Pain_de_Sucre_d'Envers_du_Plan,Pain de Sucre d'Envers du Plan,6.90917,45.89,3607.0,Aiguilles de Chamonix,sommet,5,Pain de Sucre d'Envers du Plan,Aiguilles de Chamonix
+332,http://fr.dbpedia.org/resource/Palastre,Palastre,6.20889,44.6931,2278.0,Écrins,sommet,5,Palastre,Écrins
+208,http://fr.dbpedia.org/resource/Paradiski,Paradiski,6.75934,45.5459,0.0,Vanoise,ski,5,Paradiski,
+511,http://fr.dbpedia.org/resource/Parmelan,Parmelan,6.23806,45.9483,1832.0,Bornes,sommet,5,Parmelan,Bornes
+674,http://fr.dbpedia.org/resource/Parrossaz,Parrossaz,6.485,45.8881,2556.0,Aravis,sommet,5,Parrossaz,Aravis
+148,http://fr.dbpedia.org/resource/Pas_de_Morgins,Pas de Morgins,6.84611,46.2494,1371.0,Chablais,col,5,Pas de Morgins,Chablais
+140,http://fr.dbpedia.org/resource/Pas_de_l'Âne,Pas de l'Âne,6.49278,45.6808,2371.0,Beaufortain,col,5,Pas de l'Âne,Beaufortain
+47,http://fr.dbpedia.org/resource/Pas_de_la_Faye,Pas de la Faye,6.8376,43.7114,981.0,Préalpes de Castellane,col,5,Pas de la Faye,Préalpes de Castellane
+118,http://fr.dbpedia.org/resource/Pas_du_Préfouns,Pas du Préfouns,7.23139,44.1708,2615.0,Mercantour,col,5,Pas du Préfouns,Mercantour
+333,http://fr.dbpedia.org/resource/Petit_Pinier,Petit Pinier,6.40556,44.7061,3100.0,Écrins,sommet,5,Petit Pinier,Écrins
+687,http://fr.dbpedia.org/resource/Petite_Aiguille_Verte,Petite Aiguille Verte,6.96333,45.9436,3512.0,Mont-Blanc,sommet,5,Petite Aiguille Verte,Mont-Blanc
+692,http://fr.dbpedia.org/resource/Petite_Autane,Petite Autane,6.24694,44.6408,2519.0,Écrins,sommet,5,Petite Autane,Écrins
+301,http://fr.dbpedia.org/resource/Petite_Bosse,Petite Bosse,6.85472,45.8361,4547.0,Mont-Blanc,sommet,5,Petite Bosse,Mont-Blanc
+723,http://fr.dbpedia.org/resource/Peygros,Peygros,6.68944,43.6611,778.0,Préalpes de Castellane,sommet,5,Peygros,Préalpes de Castellane
+562,http://fr.dbpedia.org/resource/Peyrouse_(sommet),Peyrouse (sommet),5.72472,44.9922,1710.0,Taillefer,sommet,5,Peyrouse,Taillefer
+741,http://fr.dbpedia.org/resource/Pic_Bayle,Pic Bayle,6.13583,45.1381,3465.0,Grandes Rousses,sommet,5,Pic Bayle,Grandes Rousses
+536,http://fr.dbpedia.org/resource/Pic_Gaspard,Pic Gaspard,6.33083,44.9983,3881.0,Écrins,sommet,5,Pic Gaspard,Écrins
+827,http://fr.dbpedia.org/resource/Pic_Lory,Pic Lory,6.35806,44.9219,4088.0,Écrins,sommet,5,Pic Lory,Écrins
+465,http://fr.dbpedia.org/resource/Pic_Queyrel,Pic Queyrel,6.14528,44.7069,2435.0,Écrins,sommet,5,Pic Queyrel,Écrins
+754,http://fr.dbpedia.org/resource/Pic_Sans_Nom,Pic Sans Nom,6.38333,44.8933,3913.0,Écrins,sommet,5,Pic Sans Nom,Écrins
+359,http://fr.dbpedia.org/resource/Pic_de_Caramantran,Pic de Caramantran,6.96333,44.6783,3025.0,Escreins,sommet,5,Pic de Caramantran,Escreins
+675,http://fr.dbpedia.org/resource/Pic_de_Jallouvre,Pic de Jallouvre,6.45222,45.9958,2408.0,Bornes,sommet,5,Pic de Jallouvre,Bornes
+537,http://fr.dbpedia.org/resource/Pic_de_Neige_Cordier,Pic de Neige Cordier,6.38889,44.9561,3614.0,Écrins,sommet,5,Pic de Neige Cordier,Écrins
+656,http://fr.dbpedia.org/resource/Pic_de_Rochebrune,Pic de Rochebrune,6.78722,44.8225,3320.0,Queyras,sommet,5,Pic de Rochebrune,Queyras
+334,http://fr.dbpedia.org/resource/Pic_de_Tenneverge,Pic de Tenneverge,6.87944,46.0942,2989.0,Giffre,sommet,5,Pic de Tenneverge,Giffre
+478,http://fr.dbpedia.org/resource/Pic_de_la_Belle_Étoile,Pic de la Belle Étoile,6.05417,45.2367,2718.0,Belledonne,sommet,5,Pic de la Belle Étoile,Belledonne
+427,http://fr.dbpedia.org/resource/Pic_du_Frêne,Pic du Frêne,6.19806,45.3525,2807.0,Belledonne,sommet,5,Pic du Frêne,Belledonne
+786,http://fr.dbpedia.org/resource/Pic_du_Grand_Doménon,Pic du Grand Doménon,5.97111,45.1617,2802.0,Belledonne,sommet,5,Pic du Grand Doménon,Belledonne
+466,http://fr.dbpedia.org/resource/Pic_du_Tourond,Pic du Tourond,6.18944,44.7161,2743.0,Écrins,sommet,5,Pic du Tourond,Écrins
+513,http://fr.dbpedia.org/resource/Pics_de_Combeynot,Pics de Combeynot,6.41083,45.0125,3155.0,Écrins,sommet,5,Pics de Combeynot,Écrins
+742,http://fr.dbpedia.org/resource/Pics_de_la_Font_Sancte,Pics de la Font Sancte,6.79972,44.6047,3385.0,Escreins,sommet,5,Pics de la Font Sancte,Escreins
+539,http://fr.dbpedia.org/resource/Pinéa,Pinéa,5.73861,45.2883,1771.0,Chartreuse,sommet,5,Pinéa,Chartreuse
+563,http://fr.dbpedia.org/resource/Pié_Ferré,Pié Ferré,5.47028,44.7372,2041.0,Vercors,sommet,5,Pié Ferré,Vercors
+457,http://fr.dbpedia.org/resource/Pointe_Bayeux,Pointe Bayeux,6.84389,45.8464,4258.0,Mont-Blanc,sommet,5,Pointe Bayeux,Mont-Blanc
+676,http://fr.dbpedia.org/resource/Pointe_Blanche_(montagne),Pointe Blanche (montagne),6.46,45.9989,2438.0,Bornes,sommet,5,Pointe Blanche,Bornes
+713,http://fr.dbpedia.org/resource/Pointe_Côte_de_l'Âne,Pointe Côte de l'Âne,6.80444,44.2444,2916.0,Mercantour,sommet,5,Pointe Côte de l'Âne,Mercantour
+367,http://fr.dbpedia.org/resource/Pointe_Giegn,Pointe Giegn,7.22361,44.1633,2888.0,Mercantour,sommet,5,Pointe Giegn,Mercantour
+540,http://fr.dbpedia.org/resource/Pointe_Guyard,Pointe Guyard,6.39083,44.8597,3461.0,Écrins,sommet,5,Pointe Guyard,Écrins
+828,http://fr.dbpedia.org/resource/Pointe_Helbronner,Pointe Helbronner,6.93167,45.8458,3462.0,Mont-Blanc,sommet,5,Pointe Helbronner,Mont-Blanc
+489,http://fr.dbpedia.org/resource/Pointe_Marguareis,Pointe Marguareis,7.68472,44.1739,2651.0,Alpes ligures,sommet,5,Pointe Marguareis,Alpes ligures
+355,http://fr.dbpedia.org/resource/Pointe_Noire_de_Pormenaz,Pointe Noire de Pormenaz,6.80111,45.9583,2323.0,Pormenaz,sommet,5,Pointe Noire de Pormenaz,Pormenaz
+424,http://fr.dbpedia.org/resource/Pointe_Richardson,Pointe Richardson,6.32028,44.8569,3312.0,Écrins,sommet,5,Pointe Richardson,Écrins
+335,http://fr.dbpedia.org/resource/Pointe_Rousse,Pointe Rousse,6.7925,46.0972,2577.0,Giffre,sommet,5,Pointe Rousse,Giffre
+787,http://fr.dbpedia.org/resource/Pointe_Rénod,Pointe Rénod,6.60528,45.2458,3368.0,Vanoise,sommet,5,Pointe Rénod,Vanoise
+698,http://fr.dbpedia.org/resource/Pointe_Sommeiller,Pointe Sommeiller,6.85222,45.1278,3332.0,Mont-Cenis,sommet,5,Pointe Sommeiller,Mont-Cenis
+755,http://fr.dbpedia.org/resource/Pointe_d'Andey,Pointe d'Andey,6.41806,46.0428,1877.0,Bornes,sommet,5,Pointe d'Andey,Bornes
+336,http://fr.dbpedia.org/resource/Pointe_d'Anterne,Pointe d'Anterne,6.78528,45.9797,2733.0,Giffre,sommet,5,Pointe d'Anterne,Giffre
+809,http://fr.dbpedia.org/resource/Pointe_d'Areu,Pointe d'Areu,6.57944,45.9817,2478.0,Aravis,sommet,5,Pointe d'Areu,Aravis
+829,http://fr.dbpedia.org/resource/Pointe_d'Ireuse,Pointe d'Ireuse,6.575,46.2675,1890.0,Chablais,sommet,5,Pointe d'Ireuse,Chablais
+830,http://fr.dbpedia.org/resource/Pointe_d'Uble,Pointe d'Uble,6.59972,46.1681,1963.0,Chablais,sommet,5,Pointe d'Uble,Chablais
+678,http://fr.dbpedia.org/resource/Pointe_de_Bella_Cha,Pointe de Bella Cha,6.56361,45.9717,2511.0,Aravis,sommet,5,Pointe de Bella Cha,Aravis
+831,http://fr.dbpedia.org/resource/Pointe_de_Chalune,Pointe de Chalune,6.58139,46.18,2116.0,Chablais,sommet,5,Pointe de Chalune,Chablais
+415,http://fr.dbpedia.org/resource/Pointe_de_Charbonnel,Pointe de Charbonnel,7.05556,45.2808,3752.0,Alpes grées,sommet,5,Pointe de Charbonnel,Alpes grées
+743,http://fr.dbpedia.org/resource/Pointe_de_Chavanette,Pointe de Chavanette,6.80694,46.1781,2219.0,Chablais,sommet,5,Pointe de Chavanette,Chablais
+832,http://fr.dbpedia.org/resource/Pointe_de_Chavannais,Pointe de Chavannais,6.54944,46.1792,1851.0,Chablais,sommet,5,Pointe de Chavannais,Chablais
+833,http://fr.dbpedia.org/resource/Pointe_de_Chavasse,Pointe de Chavasse,6.56917,46.1764,2012.0,Chablais,sommet,5,Pointe de Chavasse,Chablais
+744,http://fr.dbpedia.org/resource/Pointe_de_Chésery,Pointe de Chésery,6.80361,46.2033,2251.0,Chablais,sommet,5,Pointe de Chésery,Chablais
+788,http://fr.dbpedia.org/resource/Pointe_de_Claret,Pointe de Claret,6.97111,45.3419,3355.0,Vanoise,sommet,5,Pointe de Claret,Vanoise
+745,http://fr.dbpedia.org/resource/Pointe_de_Fornet,Pointe de Fornet,6.79194,46.1633,2300.0,Chablais,sommet,5,Pointe de Fornet,Chablais
+302,http://fr.dbpedia.org/resource/Pointe_de_Marcelly,Pointe de Marcelly,6.57528,46.1286,1999.0,Chablais,sommet,5,Pointe de Marcelly,Chablais
+834,http://fr.dbpedia.org/resource/Pointe_de_Miribel,Pointe de Miribel,6.47417,46.2117,1581.0,Chablais,sommet,5,Pointe de Miribel,Chablais
+789,http://fr.dbpedia.org/resource/Pointe_de_Méan_Martin,Pointe de Méan Martin,6.99,45.3672,3330.0,Vanoise,sommet,5,Pointe de Méan Martin,Vanoise
+564,http://fr.dbpedia.org/resource/Pointe_de_Nantaux,Pointe de Nantaux,6.70806,46.2258,2170.0,Chablais,sommet,5,Pointe de Nantaux,Chablais
+337,http://fr.dbpedia.org/resource/Pointe_de_Nyon,Pointe de Nyon,6.72194,46.1467,2019.0,Giffre,sommet,5,Pointe de Nyon,Giffre
+699,http://fr.dbpedia.org/resource/Pointe_de_Paumont,Pointe de Paumont,6.72861,45.1392,3171.0,Mont-Cenis,sommet,5,Pointe de Paumont,Mont-Cenis
+862,http://fr.dbpedia.org/resource/Pointe_de_Platé,Pointe de Platé,6.73056,45.9653,2554.0,0,sommet,5,Pointe de Platé,
+746,http://fr.dbpedia.org/resource/Pointe_de_Ronce,Pointe de Ronce,6.97833,45.2647,3612.0,Mont-Cenis,sommet,5,Pointe de Ronce,Mont-Cenis
+693,http://fr.dbpedia.org/resource/Pointe_de_Rougnoux,Pointe de Rougnoux,6.35944,44.7583,3179.0,Écrins,sommet,5,Pointe de Rougnoux,Écrins
+428,http://fr.dbpedia.org/resource/Pointe_de_Sur_Cou,Pointe de Sur Cou,6.34639,46.02,1809.0,Bornes,sommet,5,Pointe de Sur Cou,Bornes
+356,http://fr.dbpedia.org/resource/Pointe_de_Thivelet,Pointe de Thivelet,5.82194,45.4347,1231.0,Chartreuse,sommet,5,Pointe de Thivelet,Chartreuse
+790,http://fr.dbpedia.org/resource/Pointe_de_Thorens,Pointe de Thorens,6.60944,45.2647,3266.0,Vanoise,sommet,5,Pointe de Thorens,Vanoise
+321,http://fr.dbpedia.org/resource/Pointe_de_Tierce,Pointe de Tierce,7.01306,45.3083,2973.0,Alpes grées,sommet,5,Pointe de Tierce,Alpes grées
+747,http://fr.dbpedia.org/resource/Pointe_de_Vorlaz,Pointe de Vorlaz,6.79972,46.1817,2346.0,Chablais,sommet,5,Pointe de Vorlaz,Chablais
+429,http://fr.dbpedia.org/resource/Pointe_de_l'Aiglière,Pointe de l'Aiglière,6.41472,44.8103,3307.0,Écrins,sommet,5,Pointe de l'Aiglière,Écrins
+430,http://fr.dbpedia.org/resource/Pointe_de_l'Échelle,Pointe de l'Échelle,6.685,45.2692,3422.0,Vanoise,sommet,5,Pointe de l'Échelle,Vanoise
+791,http://fr.dbpedia.org/resource/Pointe_de_la_Fournache,Pointe de la Fournache,6.7525,45.2875,3642.0,Vanoise,sommet,5,Pointe de la Fournache,Vanoise
+714,http://fr.dbpedia.org/resource/Pointe_de_la_Galise,Pointe de la Galise,7.10444,45.4669,3343.0,Alpes grées,sommet,5,Pointe de la Galise,Alpes grées
+497,http://fr.dbpedia.org/resource/Pointe_de_la_Galoppaz,Pointe de la Galoppaz,6.06667,45.5658,1681.0,Bauges,sommet,5,Pointe de la Galoppaz,Bauges
+835,http://fr.dbpedia.org/resource/Pointe_de_la_Gay,Pointe de la Gay,6.57306,46.2297,1801.0,Chablais,sommet,5,Pointe de la Gay,Chablais
+854,http://fr.dbpedia.org/resource/Pointe_de_la_Gorgeat,Pointe de la Gorgeat,5.89389,45.4967,1486.0,Chartreuse,sommet,5,Pointe de la Gorgeat,Chartreuse
+792,http://fr.dbpedia.org/resource/Pointe_de_la_Grande_Journée,Pointe de la Grande Journée,6.50111,45.6672,2460.0,Beaufortain,sommet,5,Pointe de la Grande Journée,Beaufortain
+338,http://fr.dbpedia.org/resource/Pointe_de_la_Masse,Pointe de la Masse,6.5093,45.2971,2804.0,Vanoise,sommet,5,Pointe de la Masse,Vanoise
+793,http://fr.dbpedia.org/resource/Pointe_de_la_Réchasse,Pointe de la Réchasse,6.80194,45.3733,3212.0,Vanoise,sommet,5,Pointe de la Réchasse,Vanoise
+657,http://fr.dbpedia.org/resource/Pointe_de_la_Sana,Pointe de la Sana,6.9175,45.3853,3436.0,Vanoise,sommet,5,Pointe de la Sana,Vanoise
+360,http://fr.dbpedia.org/resource/Pointe_de_la_Terrasse_(Giffre),Pointe de la Terrasse (Giffre),6.89222,46.0417,2734.0,Giffre,sommet,5,Pointe de la Terrasse,Giffre
+794,http://fr.dbpedia.org/resource/Pointe_de_la_Terrasse_(Beaufortain),Pointe de la Terrasse (Beaufortain),6.72444,45.6703,2881.0,Beaufortain,sommet,5,Pointe de la Terrasse,Beaufortain
+541,http://fr.dbpedia.org/resource/Pointe_des_Arcas,Pointe des Arcas,6.4475,44.9264,3479.0,Écrins,sommet,5,Pointe des Arcas,Écrins
+836,http://fr.dbpedia.org/resource/Pointe_des_Brasses,Pointe des Brasses,6.44278,46.1633,1503.0,Chablais,sommet,5,Pointe des Brasses,Chablais
+795,http://fr.dbpedia.org/resource/Pointe_des_Buffettes,Pointe des Buffettes,7.00722,45.3656,3233.0,Vanoise,sommet,5,Pointe des Buffettes,Vanoise
+431,http://fr.dbpedia.org/resource/Pointe_des_Jottis,Pointe des Jottis,6.52722,46.2136,1548.0,Chablais,sommet,5,Pointe des Jottis,Chablais
+796,http://fr.dbpedia.org/resource/Pointe_du_Bouchet,Pointe du Bouchet,6.60417,45.2539,3420.0,Vanoise,sommet,5,Pointe du Bouchet,Vanoise
+719,http://fr.dbpedia.org/resource/Pointe_du_Charbonnier,Pointe du Charbonnier,6.90111,45.3806,3311.0,Vanoise,sommet,5,Pointe du Charbonnier,Vanoise
+797,http://fr.dbpedia.org/resource/Pointe_du_Dard,Pointe du Dard,6.76556,45.3639,3206.0,Vanoise,sommet,5,Pointe du Dard,Vanoise
+361,http://fr.dbpedia.org/resource/Pointe_du_Lamet,Pointe du Lamet,6.99889,45.2394,3504.0,Mont-Cenis,sommet,5,Pointe du Lamet,Mont-Cenis
+467,http://fr.dbpedia.org/resource/Pointe_du_Lingustier,Pointe du Lingustier,6.1613,44.7073,2359.0,Écrins,sommet,5,Pointe du Lingustier,Écrins
+837,http://fr.dbpedia.org/resource/Pointe_du_Vallon_des_Étages,Pointe du Vallon des Étages,6.26889,44.8853,3564.0,Écrins,sommet,5,Pointe du Vallon des Étages,Écrins
+798,http://fr.dbpedia.org/resource/Pointe_du_Vallonnet,Pointe du Vallonnet,6.76083,45.4172,3372.0,Vanoise,sommet,5,Pointe du Vallonnet,Vanoise
+326,http://fr.dbpedia.org/resource/Pointe_inférieure_du_Tricot,Pointe inférieure du Tricot,6.7825,45.8461,2830.0,Mont-Blanc,sommet,5,Pointe inférieure du Tricot,Mont-Blanc
+314,http://fr.dbpedia.org/resource/Pointe-Basse_de_Mary,Pointe-Basse de Mary,6.88972,44.5828,3126.0,Chambeyron,sommet,5,Pointe-Basse de Mary,Chambeyron
+315,http://fr.dbpedia.org/resource/Pointe-Haute_de_Mary,Pointe-Haute de Mary,6.89472,44.5753,3206.0,Chambeyron,sommet,5,Pointe-Haute de Mary,Chambeyron
+799,http://fr.dbpedia.org/resource/Pointes_du_Châtelard,Pointes du Châtelard,6.955,45.3317,3479.0,Vanoise,sommet,5,Pointes du Châtelard,Vanoise
+748,http://fr.dbpedia.org/resource/Pointes_et_aiguille_de_l'Épéna,Pointes et aiguille de l'Épéna,6.81722,45.4142,3421.0,Vanoise,sommet,5,Pointes et aiguille de l'Épéna,Vanoise
+212,http://fr.dbpedia.org/resource/Portes_du_Soleil,Portes du Soleil,6.77333,46.1937,0.0,Chablais,ski,5,Portes du Soleil,
+705,http://fr.dbpedia.org/resource/Punta_dell'Alp,Punta dell'Alp,6.97111,44.6772,3033.0,Escreins,sommet,5,Punta dell'Alp,Escreins
+468,http://fr.dbpedia.org/resource/Puy_de_Manse,Puy de Manse,6.15472,44.6147,1637.0,Écrins,sommet,5,Puy de Manse,Écrins
+855,http://fr.dbpedia.org/resource/Puy_de_Rent,Puy de Rent,6.59028,44.0211,1996.0,Préalpes de Castellane,sommet,5,Puy de Rent,Préalpes de Castellane
+455,http://fr.dbpedia.org/resource/Pécloz,Pécloz,6.23111,45.6322,2197.0,Bauges,sommet,5,Pécloz,Bauges
+436,http://fr.dbpedia.org/resource/Quatre_Têtes,Quatre Têtes,6.57278,45.9539,2364.0,Aravis,sommet,5,Quatre Têtes,Aravis
+479,http://fr.dbpedia.org/resource/Rachais,Rachais,5.74361,45.2417,1050.0,Chartreuse,sommet,5,Rachais,Chartreuse
+720,http://fr.dbpedia.org/resource/Rateau_d'Aussois,Rateau d'Aussois,6.69389,45.2464,3131.0,Vanoise,sommet,5,Rateau d'Aussois,Vanoise
+565,http://fr.dbpedia.org/resource/Roc_Cornafion,Roc Cornafion,5.60083,45.0622,2049.0,Vercors,sommet,5,Roc Cornafion,Vercors
+353,http://fr.dbpedia.org/resource/Roc_d'Arguille,Roc d'Arguille,5.8375,45.3169,1768.0,Chartreuse,sommet,5,Roc d'Arguille,Chartreuse
+381,http://fr.dbpedia.org/resource/Roc_d'Enfer,Roc d'Enfer,6.61028,46.1894,2244.0,Chablais,sommet,5,Roc d'Enfer,Chablais
+435,http://fr.dbpedia.org/resource/Roc_de_Gleisin,Roc de Gleisin,5.84806,45.4422,1434.0,Chartreuse,sommet,5,Roc de Gleisin,Chartreuse
+354,http://fr.dbpedia.org/resource/Roc_des_Bœufs,Roc des Bœufs,6.16611,45.7542,1774.0,Bauges,sommet,5,Roc des Bœufs,Bauges
+800,http://fr.dbpedia.org/resource/Roc_des_Saints-Pères,Roc des Saints-Pères,6.61583,45.2789,3470.0,Vanoise,sommet,5,Roc des Saints-Pères,Vanoise
+339,http://fr.dbpedia.org/resource/Roche_Bernaude,Roche Bernaude,6.62656,45.103,3225.0,Mont-Cenis,sommet,5,Roche Bernaude,Mont-Cenis
+801,http://fr.dbpedia.org/resource/Roche_Chevrière,Roche Chevrière,6.72194,45.2933,3281.0,Vanoise,sommet,5,Roche Chevrière,Vanoise
+542,http://fr.dbpedia.org/resource/Roche_Faurio,Roche Faurio,6.35722,44.9417,3730.0,Écrins,sommet,5,Roche Faurio,Écrins
+368,http://fr.dbpedia.org/resource/Roche_Méane,Roche Méane,6.33528,44.9703,3712.0,Écrins,sommet,5,Roche Méane,Écrins
+679,http://fr.dbpedia.org/resource/Roche_Perfia,Roche Perfia,6.51361,45.9144,2499.0,Aravis,sommet,5,Roche Perfia,Aravis
+566,http://fr.dbpedia.org/resource/Roche_Pourrie,Roche Pourrie,6.46028,45.6842,2037.0,Beaufortain,sommet,5,Roche Pourrie,Beaufortain
+411,http://fr.dbpedia.org/resource/Roche_Veyrand,Roche Veyrand,5.84444,45.4289,1429.0,Chartreuse,sommet,5,Roche Veyrand,Chartreuse
+369,http://fr.dbpedia.org/resource/Roche_du_Chardonnet,Roche du Chardonnet,6.54889,45.1019,2950.0,Cerces,sommet,5,Roche du Chardonnet,Cerces
+567,http://fr.dbpedia.org/resource/Rocher_Blanc,Rocher Blanc,6.1075,45.2417,2927.0,Belledonne,sommet,5,Rocher Blanc,Belledonne
+706,http://fr.dbpedia.org/resource/Rocher_Rond,Rocher Rond,5.82726,44.6966,2453.0,Dévoluy,sommet,5,Rocher Rond,Dévoluy
+370,http://fr.dbpedia.org/resource/Rocher_de_la_Grande_Tempête,Rocher de la Grande Tempête,6.55861,45.0803,3002.0,Cerces,sommet,5,Rocher de la Grande Tempête,Cerces
+458,http://fr.dbpedia.org/resource/Rocher_de_la_Tournette,Rocher de la Tournette,6.85944,45.8328,4677.0,Mont-Blanc,sommet,5,Rocher de la Tournette,Mont-Blanc
+406,http://fr.dbpedia.org/resource/Rochers_de_la_Balme,Rochers de la Balme,5.5375,44.9897,2063.0,Vercors,sommet,5,Rochers de la Balme,Vercors
+680,http://fr.dbpedia.org/resource/Roualle,Roualle,6.50278,45.9008,2589.0,Aravis,sommet,5,Roualle,Aravis
+384,http://fr.dbpedia.org/resource/Salève,Salève,6.14028,46.0942,1379.0,Préalpes,sommet,5,Salève,Préalpes
+498,http://fr.dbpedia.org/resource/Serre_Chevalier_(montagne),Serre Chevalier (montagne),6.55,44.9108,2491.0,Écrins,sommet,5,Serre Chevalier,Écrins
+507,http://fr.dbpedia.org/resource/Signal_de_Nave,Signal de Nave,5.53694,45.2236,1609.0,Vercors,sommet,5,Signal de Nave,Vercors
+861,http://fr.dbpedia.org/resource/Sommarel,Sommarel,5.90047,44.6463,2400.0,0,sommet,5,Sommarel,
+568,http://fr.dbpedia.org/resource/Sommet_de_Malaval,Sommet de Malaval,5.51917,44.9258,2097.0,Vercors,sommet,5,Sommet de Malaval,Vercors
+473,http://fr.dbpedia.org/resource/Sommet_de_la_Saulire,Sommet de la Saulire,6.61056,45.3833,2738.0,Vanoise,sommet,5,Sommet de la Saulire,Vanoise
+474,http://fr.dbpedia.org/resource/Sommet_des_Anges,Sommet des Anges,6.71389,44.8939,2459.0,Queyras,sommet,5,Sommet des Anges,Queyras
+724,http://fr.dbpedia.org/resource/Sommet_du_Pinet,Sommet du Pinet,5.90389,45.4325,1867.0,Chartreuse,sommet,5,Sommet du Pinet,Chartreuse
+290,http://fr.dbpedia.org/resource/Super-Châtel,Super-Châtel,6.83833,46.2814,0.0,0,ski,5,Super-Châtel,
+838,http://fr.dbpedia.org/resource/Sur_la_Pointe,Sur la Pointe,6.54333,46.235,1657.0,Chablais,sommet,5,Sur la Pointe,Chablais
+569,http://fr.dbpedia.org/resource/Tabor_(sommet),Tabor (sommet),5.85556,44.9772,2389.0,Taillefer,sommet,5,Tabor,Taillefer
+681,http://fr.dbpedia.org/resource/Tardevant,Tardevant,6.52583,45.9264,2501.0,Aravis,sommet,5,Tardevant,Aravis
+727,http://fr.dbpedia.org/resource/Tour_Noir,Tour Noir,7.0375,45.9486,3837.0,Mont-Blanc,sommet,5,Tour Noir,Mont-Blanc
+304,http://fr.dbpedia.org/resource/Trélod,Trélod,6.19639,45.6928,2181.0,Bauges,sommet,5,Trélod,Bauges
+475,http://fr.dbpedia.org/resource/Tête_Grosse,Tête Grosse,6.27361,44.3314,2032.0,Préalpes de Digne,sommet,5,Tête Grosse,Préalpes de Digne
+682,http://fr.dbpedia.org/resource/Tête_Pelouse,Tête Pelouse,6.50972,45.9092,2537.0,Aravis,sommet,5,Tête Pelouse,Aravis
+341,http://fr.dbpedia.org/resource/Tête_de_Bostan,Tête de Bostan,6.8,46.1356,2406.0,Giffre,sommet,5,Tête de Bostan,Giffre
+571,http://fr.dbpedia.org/resource/Tête_de_Chien,Tête de Chien,7.40222,43.7308,550.0,Préalpes de Nice,sommet,5,Tête de Chien,Préalpes de Nice
+839,http://fr.dbpedia.org/resource/Tête_de_Lauranoure,Tête de Lauranoure,6.15139,44.9261,3325.0,Écrins,sommet,5,Tête de Lauranoure,Écrins
+683,http://fr.dbpedia.org/resource/Tête_de_Paccaly,Tête de Paccaly,6.52,45.9189,2467.0,Aravis,sommet,5,Tête de Paccaly,Aravis
+499,http://fr.dbpedia.org/resource/Tête_de_Siguret,Tête de Siguret,6.78806,44.4414,3032.0,Mercantour,sommet,5,Tête de Siguret,Mercantour
+694,http://fr.dbpedia.org/resource/Tête_de_l'Enchastraye,Tête de l'Enchastraye,6.88778,44.3669,2954.0,Mercantour,sommet,5,Tête de l'Enchastraye,Mercantour
+707,http://fr.dbpedia.org/resource/Tête_de_l'Homme,Tête de l'Homme,6.775,44.4903,2504.0,Chambeyron,sommet,5,Tête de l'Homme,Chambeyron
+803,http://fr.dbpedia.org/resource/Tête_de_la_Cicle,Tête de la Cicle,6.68667,45.7547,2552.0,Beaufortain,sommet,5,Tête de la Cicle,Beaufortain
+545,http://fr.dbpedia.org/resource/Tête_de_la_Gandolière,Tête de la Gandolière,6.27028,44.9739,3542.0,Écrins,sommet,5,Tête de la Gandolière,Écrins
+546,http://fr.dbpedia.org/resource/Tête_des_Fétoules,Tête des Fétoules,6.23667,44.8997,3459.0,Écrins,sommet,5,Tête des Fétoules,Écrins
+342,http://fr.dbpedia.org/resource/Tête_du_Colonney,Tête du Colonney,6.69083,45.9714,2692.0,Faucigny,sommet,5,Tête du Colonney,Faucigny
+701,http://fr.dbpedia.org/resource/Tête_du_Danay,Tête du Danay,6.44861,45.9219,1731.0,Aravis,sommet,5,Tête du Danay,Aravis
+749,http://fr.dbpedia.org/resource/Tête_du_Géant,Tête du Géant,6.81639,46.22,2228.0,Chablais,sommet,5,Tête du Géant,Chablais
+323,http://fr.dbpedia.org/resource/Tête_du_Rouget,Tête du Rouget,6.26333,44.955,3418.0,Écrins,sommet,5,Tête du Rouget,Écrins
+750,http://fr.dbpedia.org/resource/Vieux_Chaillol,Vieux Chaillol,6.18972,44.7356,3163.0,Écrins,sommet,5,Vieux Chaillol,Écrins
+684,http://fr.dbpedia.org/resource/Écoutoux,Écoutoux,5.75778,45.2531,1406.0,Chartreuse,sommet,5,Écoutoux,Chartreuse
+804,http://fr.dbpedia.org/resource/Épaule_du_Bouchet,Épaule du Bouchet,6.61139,45.2594,3250.0,Vanoise,sommet,5,Épaule du Bouchet,Vanoise
+407,http://fr.dbpedia.org/resource/Éperrimont,Éperrimont,5.61778,45.0197,1441.0,Vercors,sommet,5,Éperrimont,Vercors
+305,http://fr.dbpedia.org/resource/Étale_(sommet),Étale (sommet),6.4475,45.85,2484.0,Aravis,sommet,5,Étale,Aravis
+219,http://fr.dbpedia.org/resource/Évasion_Mont-Blanc,Évasion Mont-Blanc,6.68175,45.8293,1000.0,0,ski,5,Évasion Mont-Blanc,

--- a/datasets.json
+++ b/datasets.json
@@ -127,7 +127,7 @@
         "tiles": "terrain",
         "harshness": 0.65,
         "label*": ["Facile", "Normal", "Difficile"],
-        "weights*": [[1, 0.01], [1, 0.7, 0.1], [1, 1, 0.5]]
+        "weights*": [[1, 0.02], [1, 0.8, 0.1, 0.001], [1, 1, 1, 0.5]]
       },
       {
         "map_id": "aoc_fr",

--- a/front/datasetBuilder/datasetEditor.vue
+++ b/front/datasetBuilder/datasetEditor.vue
@@ -62,7 +62,7 @@ export default {
   components: {MapSelector},
   mixins: [mapBaseMixin],
   data() {
-    const levels = [true, false, false, false, false];
+    const levels = [true, false, false, false, false, false];
     return {
       levels: levels,
       columns: [],


### PR DESCRIPTION
Use 5 groups instead of 3. Difficulty levels:
- 'Easy': 99.8% of 0
- 'Medium':  95% of 0 and 1
- 'Hard': 85% of 0, 1, 2
