### PR TITLE
Change tile provider

### DIFF
--- a/front/common/map.js
+++ b/front/common/map.js
@@ -9,7 +9,8 @@ const LAYERS = {
     labelled: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
     terrainSSL: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}',
     bw: 'http://tile.stamen.com/toner-background/{z}/{x}/{y}.png',
-    bwSSL: 'https://tiles.stadiamaps.com/tiles/stamen_toner_background/{z}/{x}/{y}{r}.png'
+    bwSSL: 'https://tiles.stadiamaps.com/tiles/stamen_toner_background/{z}/{x}/{y}{r}.png',
+    satellite: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
 };
 
 const CREDITS = `Map tiles by <a href="http://stamen.com">Stamen Design</a>,

--- a/front/map/mapBaseMixin.vue
+++ b/front/map/mapBaseMixin.vue
@@ -62,7 +62,8 @@ export default {
       else if (typeof maxZoom === "undefined"){
         this.canvas.setMaxZoom(18);
       }
-      this.map = L.tileLayer(tiles, {
+      // Force use `LAYERS.satellite` until I find a solution for Stadia usage limit
+      this.map = L.tileLayer(LAYERS.satellite, {
         zoomControl: false,
         attribution: credits,
         ...extraTileParams

--- a/front/store.js
+++ b/front/store.js
@@ -86,7 +86,9 @@ function initScore(params) {
             },
 
             autozoom(state, getters){
-                return state.playerParams.autozoom && !getters.isMobile;
+                // Force return false to reduce tile usage
+                // return state.playerParams.autozoom && !getters.isMobile;
+                return false
             },
 
             selfScore(state) {


### PR DESCRIPTION
Stadia usage quota has been reached, so the site is no longer usable. As a cheap fix, this commit:

- set tile provider to ESRI satellite imagery for all maps (i.e. the dataset configuration `tiles` is ignored). I chose this layer because it works at all zoom levels, whereas terrain basemaps (which are great) don't work for high zoom (e.g. Paris map would break)
- disable autozoom (option is still there but it does nothing)