### PR TITLE
Fix terrain style

### DIFF
--- a/front/map/map.vue
+++ b/front/map/map.vue
@@ -389,8 +389,8 @@ export default {
   background-color: blue !important;
   opacity: 1 !important;
 }
-
+/* Disable custom style until Stadia usage issue is solved
 .terrain img {
   filter: grayscale(100%) brightness(55%) contrast(450%);
-}
+}*/
 </style>


### PR DESCRIPTION
Custom CSS transform applied to `.terrain` images is no longer needed, since all maps now use the _satellite_ view.