### PR TITLE
Add version number to lobby page

### DIFF
--- a/amstramdam/__init__.py
+++ b/amstramdam/__init__.py
@@ -20,7 +20,8 @@ eventlet.monkey_patch(socket=False)
 
 # Read environment variables
 IS_LOCAL = os.environ.get("IS_HEROKU") != "1"
-IS_BETA = os.environ.get("IS_BETA") == "1"
+IS_STAGING = os.environ.get("IS_STAGING") == "1"
+APP_VERSION = os.environ.get("HEROKU_RELEASE_VERSION", "dev")
 NO_SSL = os.environ.get("NO_SSL") == "1"
 SECRET_KEY = os.environ.get("SECURE_KEY", "dummy_secure_key_for_local_debugging").split(
     ","

--- a/amstramdam/routes.py
+++ b/amstramdam/routes.py
@@ -1,6 +1,6 @@
 import os
 
-from amstramdam import app, manager, dataloader, IS_LOCAL, IS_BETA, CONF
+from amstramdam import app, manager, dataloader, IS_LOCAL, CONF, IS_STAGING, APP_VERSION
 from flask import (
     render_template,
     jsonify,
@@ -19,7 +19,10 @@ def serve_main():
         "lobby.html",
         datasets=dataloader.get_datasets(full=False),
         games=manager.get_public_games(),
-        is_beta=IS_BETA,
+        config={
+            "is_staging": IS_STAGING,
+            "version": APP_VERSION,
+        }
     )
 
 

--- a/amstramdam/templates/lobby.html
+++ b/amstramdam/templates/lobby.html
@@ -15,7 +15,7 @@
     <script type="text/javascript" charset="utf-8" nonce="[[ csp_nonce() ]]">
         const datasets = [[ datasets | tojson ]];
         const games = [[ games | tojson ]];
-        const IS_BETA = [[ is_beta | tojson ]];
+        const appConfig = [[ config | tojson]];
     </script>
     <script src="[[ url_for('static', filename='script/lobby.js') ]]"></script>
 </head>

--- a/front/lobby.js
+++ b/front/lobby.js
@@ -12,7 +12,7 @@ const USE_VUE = true;
 
 if (USE_VUE) {
     document.addEventListener("DOMContentLoaded", () => {
-        const app = createApp(AmstramdamLobby);
+        const app = createApp(AmstramdamLobby, {datasets, games, appConfig});
         app.mixin(MobileDetectionMixin);
 
         app.mount("#amstramdam-lobby");

--- a/front/lobby/footer.vue
+++ b/front/lobby/footer.vue
@@ -1,15 +1,20 @@
 <template>
 <footer id="game-sharing-link" style="z-index: 1002;">
-        <a href="https://github.com/felix-martel/amstramdam"  target="_blank">À propos</a>
-        <a href="https://github.com/felix-martel/amstramdam/issues" target="_blank">Signaler un bug</a>
-        <span style="color: white;">Demandez l'original : </span>
-        <a href="https://www.jeux-geographiques.com/"  target="_blank">Jeux-Géographiques.com</a>
+  <span >Amstramdam {{ version }}</span>
+  <a href="https://github.com/felix-martel/amstramdam"  target="_blank">À propos</a>
+  <a href="https://github.com/felix-martel/amstramdam/issues" target="_blank">Signaler un bug</a>
+  <span>Demandez l'original : </span>
+  <a href="https://www.jeux-geographiques.com/"  target="_blank">Jeux-Géographiques.com</a>
     </footer>
 </template>
 
 <script>
 export default {
-name: "footer.vue"
+  name: "footer.vue",
+  props: {
+    version: String,
+    isStaging: Boolean,
+  }
 }
 </script>
 
@@ -29,7 +34,7 @@ footer {
   align-items: center;
 }
 
-footer a, footer a:visited, footer a:hover {
+footer a, footer a:visited, footer a:hover, footer span {
   color: white;
   margin-right: 10px;
 }

--- a/front/mainLobbyPage.vue
+++ b/front/mainLobbyPage.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="main">
-    <footer-box></footer-box>
+    <footer-box :is-staging="appConfig.is_staging" :version="appConfig.version"></footer-box>
     <popup :visible="true">
       <div class="main-title">
         <h1 class="blue">
-          <span id="title" :class="{beta: IS_BETA}">am·stram·dam</span>
+          <span id="title" :class="{beta: appConfig.is_staging}">am·stram·dam</span>
         </h1>
         <div><i>Localiser les villes sur la carte, le plus rapidement possible</i></div>
       </div>
@@ -54,10 +54,14 @@ export default {
     "game-creator": gameCreator,
   },
 
+  props: {
+    datasets: Object,
+    games: Object,
+    appConfig: Object,
+  },
+
   data() {
     return {
-      datasets: datasets,
-      games: games,
       map: {map_id: ""},
       points: [],
       loading: true,


### PR DESCRIPTION
Now that app is automatically deployed on staging, it is helpful to keep track of which version is running on which environment.

:warning: Requires [Dyno Metadata](https://devcenter.heroku.com/articles/dyno-metadata) enabled on the environement, otherwise a generic `dev` version will be used.